### PR TITLE
Micha/bump 0.1.0 + update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The official SurrealDB library for .NET
 
 [![](https://img.shields.io/badge/status-beta-ff00bb.svg?style=flat-square)](https://github.com/surrealdb/surrealdb.net) [![](https://img.shields.io/badge/docs-view-44cc11.svg?style=flat-square)](https://surrealdb.com/docs/integration/libraries/dotnet) [![](https://img.shields.io/badge/license-Apache_License_2.0-00bfff.svg?style=flat-square)](https://github.com/surrealdb/surrealdb.net)
 
+⚠️ Please note that this driver is currently community maintained.
+
 ## Getting started
 
 ### Installation

--- a/SurrealDb/SurrealDb.csproj
+++ b/SurrealDb/SurrealDb.csproj
@@ -7,7 +7,7 @@
 		<Nullable>enable</Nullable>
 
 		<PackageId>SurrealDb</PackageId>
-		<Version>1.0.0-beta.1</Version>
+		<Version>0.1.0</Version>
 		<Owners>Tobie Morgan Hitchcock</Owners>
 		<Description>The official SurrealDB library for .NET</Description>
 		<PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
Decided to not go with v1.0.0-beta.x versioning, but rather start off at v0.1.0, like the other SDKs. Also added a note in the readme stating that this driver is currently community maintained