### PR TITLE
Feat/configure await

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ The official SurrealDB library for .NET.
 [![](https://img.shields.io/badge/license-Apache_License_2.0-00bfff.svg?style=flat-square)](https://github.com/surrealdb/surrealdb.net)
 [![](https://img.shields.io/nuget/v/surrealdb.net?style=flat-square)](https://www.nuget.org/packages/SurrealDb.Net)
 
-
 ⚠️ This driver is currently community maintained.
 
 ## Getting started
@@ -281,7 +280,7 @@ This project also contains [benchmarks](https://benchmarkdotnet.org/) in order t
 You will need a local SurrealDB instance alongside the tests. Start one using the following command:
 
 ```
-surreal start --log debug --user root --pass root memory --auth --allow-guests
+surreal start --user root --pass root memory --auth --allow-guests
 ```
 
 Once ready, go to the root directory of the project and run the following command:

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Http.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Http.cs
@@ -34,9 +34,11 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
 		using var wrapper = CreateHttpClientWrapper(new BearerAuth(jwt.Token));
 		using var body = CreateBodyContent("RETURN TRUE");
 
-		using var response = await wrapper.Instance.PostAsync("/sql", body, cancellationToken);
+		using var response = await wrapper.Instance
+			.PostAsync("/sql", body, cancellationToken)
+			.ConfigureAwait(false);
 
-		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken);
+		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken).ConfigureAwait(false);
 		EnsuresFirstResultOk(dbResponse);
 
 		_config.SetBearerAuth(jwt.Token);
@@ -64,9 +66,11 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
 		using var wrapper = CreateHttpClientWrapper();
 		using var body = CreateBodyContent("RETURN TRUE");
 
-		using var response = await wrapper.Instance.PostAsync("/sql", body, cancellationToken);
+		using var response = await wrapper.Instance
+			.PostAsync("/sql", body, cancellationToken)
+			.ConfigureAwait(false);
 
-		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken);
+		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken).ConfigureAwait(false);
 		EnsuresFirstResultOk(dbResponse);
 	}
 
@@ -78,9 +82,11 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
 		if (data.Id is null)
 			throw new SurrealDbException("Cannot create a record without an Id");
 
-		using var response = await wrapper.Instance.PostAsync($"/key/{data.Id.Table}/{data.Id.UnescapedId}", body, cancellationToken);
+		using var response = await wrapper.Instance
+			.PostAsync($"/key/{data.Id.Table}/{data.Id.UnescapedId}", body, cancellationToken)
+			.ConfigureAwait(false);
 
-		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken);
+		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken).ConfigureAwait(false);
 
 		var list = ExtractFirstResultValue<List<T>>(dbResponse)!;
 		return list.First();
@@ -90,9 +96,11 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
 		using var wrapper = CreateHttpClientWrapper();
 		using var body = data is null ? new StringContent("{}") : CreateBodyContent(data);
 
-		using var response = await wrapper.Instance.PostAsync($"/key/{table}", body, cancellationToken);
+		using var response = await wrapper.Instance
+			.PostAsync($"/key/{table}", body, cancellationToken)
+			.ConfigureAwait(false);
 
-		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken);
+		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken).ConfigureAwait(false);
 
 		var list = ExtractFirstResultValue<List<T>>(dbResponse)!;
 		return list.First();
@@ -102,18 +110,22 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
 	{
 		using var wrapper = CreateHttpClientWrapper();
 
-		using var response = await wrapper.Instance.DeleteAsync($"/key/{table}", cancellationToken);
+		using var response = await wrapper.Instance
+			.DeleteAsync($"/key/{table}", cancellationToken)
+			.ConfigureAwait(false);
 
-		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken);
+		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken).ConfigureAwait(false);
 		EnsuresFirstResultOk(dbResponse);
 	}
 	public async Task<bool> Delete(Thing thing, CancellationToken cancellationToken)
 	{
 		using var wrapper = CreateHttpClientWrapper();
 
-		using var response = await wrapper.Instance.DeleteAsync($"/key/{thing.Table}/{thing.UnescapedId}", cancellationToken);
+		using var response = await wrapper.Instance
+			.DeleteAsync($"/key/{thing.Table}/{thing.UnescapedId}", cancellationToken)
+			.ConfigureAwait(false);
 
-		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken);
+		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken).ConfigureAwait(false);
 
 		var list = ExtractFirstResultValue<List<object>>(dbResponse)!;
 		return list.Any(r => r is not null);
@@ -131,7 +143,10 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
 
 		try
 		{
-			using var response = await wrapper.Instance.GetAsync("/health", cancellationToken);
+			using var response = await wrapper.Instance
+				.GetAsync("/health", cancellationToken)
+				.ConfigureAwait(false);
+			
 			return response.IsSuccessStatusCode;
 		}
 		catch (HttpRequestException)
@@ -154,9 +169,11 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
 		if (data.Id is null)
 			throw new SurrealDbException("Cannot create a record without an Id");
 
-		using var response = await wrapper.Instance.PatchAsync($"/key/{data.Id.Table}/{data.Id.UnescapedId}", body, cancellationToken);
+		using var response = await wrapper.Instance
+			.PatchAsync($"/key/{data.Id.Table}/{data.Id.UnescapedId}", body, cancellationToken)
+			.ConfigureAwait(false);
 
-		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken);
+		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken).ConfigureAwait(false);
 
 		var list = ExtractFirstResultValue<List<TOutput>>(dbResponse)!;
 		return list.First();
@@ -166,9 +183,11 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
 		using var wrapper = CreateHttpClientWrapper();
 		using var body = CreateBodyContent(data);
 
-		using var response = await wrapper.Instance.PatchAsync($"/key/{thing.Table}/{thing.UnescapedId}", body, cancellationToken);
+		using var response = await wrapper.Instance
+			.PatchAsync($"/key/{thing.Table}/{thing.UnescapedId}", body, cancellationToken)
+			.ConfigureAwait(false);
 
-		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken);
+		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken).ConfigureAwait(false);
 
 		var list = ExtractFirstResultValue<List<T>>(dbResponse)!;
 		return list.First();
@@ -203,27 +222,33 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
 		};
 		var requestUri = uriBuilder.ToString();
 
-		using var response = await wrapper.Instance.PostAsync(requestUri, body, cancellationToken);
+		using var response = await wrapper.Instance
+			.PostAsync(requestUri, body, cancellationToken)
+			.ConfigureAwait(false);
 
-		return await DeserializeDbResponseAsync(response, cancellationToken);
+		return await DeserializeDbResponseAsync(response, cancellationToken).ConfigureAwait(false);
 	}
 
 	public async Task<List<T>> Select<T>(string table, CancellationToken cancellationToken)
 	{
 		using var wrapper = CreateHttpClientWrapper();
 
-		using var response = await wrapper.Instance.GetAsync($"/key/{table}", cancellationToken);
+		using var response = await wrapper.Instance
+			.GetAsync($"/key/{table}", cancellationToken)
+			.ConfigureAwait(false);
 
-		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken);
+		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken).ConfigureAwait(false);
 		return ExtractFirstResultValue<List<T>>(dbResponse)!;
 	}
     public async Task<T?> Select<T>(Thing thing, CancellationToken cancellationToken)
 	{
 		using var wrapper = CreateHttpClientWrapper();
 
-		using var response = await wrapper.Instance.GetAsync($"/key/{thing.Table}/{thing.UnescapedId}", cancellationToken);
+		using var response = await wrapper.Instance
+			.GetAsync($"/key/{thing.Table}/{thing.UnescapedId}", cancellationToken)
+			.ConfigureAwait(false);
 
-		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken);
+		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken).ConfigureAwait(false);
 
 		var list = ExtractFirstResultValue<List<T>>(dbResponse)!;
 		return list.FirstOrDefault();
@@ -235,7 +260,8 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
             $"RETURN ${key}", 
             new Dictionary<string, object>() { { key, value } }, 
             cancellationToken
-        );
+        ).ConfigureAwait(false);
+
 		EnsuresFirstResultOk(dbResponse);
 
 		_config.SetParam(key, value);
@@ -246,7 +272,9 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
         using var wrapper = CreateHttpClientWrapper();
 		using var body = CreateBodyContent(rootAuth);
 
-		using var response = await wrapper.Instance.PostAsync("/signin", body, cancellationToken);
+		using var response = await wrapper.Instance
+			.PostAsync("/signin", body, cancellationToken)
+			.ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
         _config.SetBasicAuth(rootAuth.Username, rootAuth.Password);
@@ -256,10 +284,12 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
 		using var wrapper = CreateHttpClientWrapper();
 		using var body = CreateBodyContent(nsAuth);
 
-		using var response = await wrapper.Instance.PostAsync("/signin", body, cancellationToken);
+		using var response = await wrapper.Instance
+			.PostAsync("/signin", body, cancellationToken)
+			.ConfigureAwait(false);
 		response.EnsureSuccessStatusCode();
 
-		var result = await DeserializeAuthResponse(response, cancellationToken);
+		var result = await DeserializeAuthResponse(response, cancellationToken).ConfigureAwait(false);
 
 		_config.SetBearerAuth(result.Token!);
 
@@ -270,10 +300,12 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
 		using var wrapper = CreateHttpClientWrapper();
 		using var body = CreateBodyContent(dbAuth);
 
-		using var response = await wrapper.Instance.PostAsync("/signin", body, cancellationToken);
+		using var response = await wrapper.Instance
+			.PostAsync("/signin", body, cancellationToken)
+			.ConfigureAwait(false);
 		response.EnsureSuccessStatusCode();
 
-		var result = await DeserializeAuthResponse(response, cancellationToken);
+		var result = await DeserializeAuthResponse(response, cancellationToken).ConfigureAwait(false);
 
 		_config.SetBearerAuth(result.Token!);
 
@@ -284,10 +316,12 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
 		using var wrapper = CreateHttpClientWrapper();
 		using var body = CreateBodyContent(scopeAuth);
 
-		using var response = await wrapper.Instance.PostAsync("/signin", body, cancellationToken);
+		using var response = await wrapper.Instance
+			.PostAsync("/signin", body, cancellationToken)
+			.ConfigureAwait(false);
 		response.EnsureSuccessStatusCode();
 
-		var result = await DeserializeAuthResponse(response, cancellationToken);
+		var result = await DeserializeAuthResponse(response, cancellationToken).ConfigureAwait(false);
 
 		_config.SetBearerAuth(result.Token!);
 
@@ -299,10 +333,12 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
 		using var wrapper = CreateHttpClientWrapper();
 		using var body = CreateBodyContent(scopeAuth);
 
-		using var response = await wrapper.Instance.PostAsync("/signup", body, cancellationToken);
+		using var response = await wrapper.Instance
+			.PostAsync("/signup", body, cancellationToken)
+			.ConfigureAwait(false);
 		response.EnsureSuccessStatusCode();
 
-		var result = await DeserializeAuthResponse(response, cancellationToken);
+		var result = await DeserializeAuthResponse(response, cancellationToken).ConfigureAwait(false);
 
 		return new Jwt { Token = result.Token! };
 	}
@@ -321,9 +357,11 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
 		if (data.Id is null)
 			throw new SurrealDbException("Cannot create a record without an Id");
 
-		using var response = await wrapper.Instance.PutAsync($"/key/{data.Id.Table}/{data.Id.UnescapedId}", body, cancellationToken);
+		using var response = await wrapper.Instance
+			.PutAsync($"/key/{data.Id.Table}/{data.Id.UnescapedId}", body, cancellationToken)
+			.ConfigureAwait(false);
 
-		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken);
+		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken).ConfigureAwait(false);
 
 		var list = ExtractFirstResultValue<List<T>>(dbResponse)!;
 		return list.First();
@@ -334,9 +372,11 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
 		using var wrapper = CreateHttpClientWrapper(null, new UseConfiguration { Ns = ns, Db = db });
 		using var body = CreateBodyContent("RETURN TRUE");
 
-		using var response = await wrapper.Instance.PostAsync("/sql", body, cancellationToken);
+		using var response = await wrapper.Instance
+			.PostAsync("/sql", body, cancellationToken)
+			.ConfigureAwait(false);
 
-		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken);
+		var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken).ConfigureAwait(false);
 		EnsuresFirstResultOk(dbResponse);
 
 		_config.Use(ns, db);
@@ -345,7 +385,7 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
 	public async Task<string> Version(CancellationToken _)
 	{
 		using var wrapper = CreateHttpClientWrapper();
-		return await wrapper.Instance.GetStringAsync("/version");
+		return await wrapper.Instance.GetStringAsync("/version").ConfigureAwait(false);
 	}
 
 	private HttpClientWrapper CreateHttpClientWrapper(IAuth? overridedAuth = null, UseConfiguration? useConfiguration = null)
@@ -471,20 +511,25 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
 	)
 	{
 #if NET6_0_OR_GREATER
-		using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+		using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #else
-        using var stream = await response.Content.ReadAsStreamAsync();
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #endif
 
 		if (!response.IsSuccessStatusCode)
 		{
-			var result = await JsonSerializer.DeserializeAsync<ISurrealDbResult>(stream, SurrealDbSerializerOptions.Default, cancellationToken);
+			var result = await JsonSerializer
+				.DeserializeAsync<ISurrealDbResult>(stream, SurrealDbSerializerOptions.Default, cancellationToken)
+				.ConfigureAwait(false);
 			return new SurrealDbResponse(result!);
 		}
 
 		var list = new List<ISurrealDbResult>();
 
-		await foreach (var result in JsonSerializer.DeserializeAsyncEnumerable<ISurrealDbResult>(stream, SurrealDbSerializerOptions.Default, cancellationToken))
+		await foreach (var result in JsonSerializer
+			.DeserializeAsyncEnumerable<ISurrealDbResult>(stream, SurrealDbSerializerOptions.Default, cancellationToken)
+			.ConfigureAwait(false)
+		)
 		{
 			if (result is not null)
 				list.Add(result);
@@ -499,16 +544,16 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
 	)
 	{
 #if NET6_0_OR_GREATER
-		using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+		using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #else
-		using var stream = await response.Content.ReadAsStreamAsync();
+		using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #endif
 
 		var authResponse = await JsonSerializer.DeserializeAsync<AuthResponse>(
 			stream,
 			SurrealDbSerializerOptions.Default,
 			cancellationToken
-		);
+		).ConfigureAwait(false);
 
 		if (authResponse is null)
 			throw new SurrealDbException("Cannot deserialize auth response");

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
@@ -65,7 +65,7 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 									stream,
 									SurrealDbSerializerOptions.Default,
 									cancellationToken
-								);
+								).ConfigureAwait(false);
 								break;
 							}
 					}
@@ -93,7 +93,7 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 
     public async Task Authenticate(Jwt jwt, CancellationToken cancellationToken)
 	{
-		await SendRequest("authenticate", new() { jwt.Token }, cancellationToken);
+		await SendRequest("authenticate", new() { jwt.Token }, cancellationToken).ConfigureAwait(false);
 	}
 
 	public void Configure(string? ns, string? db, string? username, string? password)
@@ -120,16 +120,16 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 		if (_wsClient.IsStarted)
 			throw new SurrealDbException("Client already started");
 
-		await _wsClient.StartOrFail();
+		await _wsClient.StartOrFail().ConfigureAwait(false);
 
 		if (_config.Ns is not null)
-			await Use(_config.Ns, _config.Db!, cancellationToken);
+			await Use(_config.Ns, _config.Db!, cancellationToken).ConfigureAwait(false);
 
 		if (_config.Auth is BasicAuth basicAuth)
-			await SignIn(new RootAuth { Username = basicAuth.Username, Password = basicAuth.Password! }, cancellationToken);
+			await SignIn(new RootAuth { Username = basicAuth.Username, Password = basicAuth.Password! }, cancellationToken).ConfigureAwait(false);
 
 		if (_config.Auth is BearerAuth bearerAuth)
-			await Authenticate(new Jwt { Token = bearerAuth.Token }, cancellationToken);
+			await Authenticate(new Jwt { Token = bearerAuth.Token }, cancellationToken).ConfigureAwait(false);
 
 		_config.Reset();
 	}
@@ -139,12 +139,12 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 		if (data.Id is null)
 			throw new SurrealDbException("Cannot create a record without an Id");
 
-		var dbResponse = await SendRequest("create", new() { data.Id.ToString(), data }, cancellationToken);
+		var dbResponse = await SendRequest("create", new() { data.Id.ToString(), data }, cancellationToken).ConfigureAwait(false);
 		return dbResponse.GetValue<T>()!;
 	}
 	public async Task<T> Create<T>(string table, T? data, CancellationToken cancellationToken)
 	{
-		var dbResponse = await SendRequest("create", new() { table, data }, cancellationToken);
+		var dbResponse = await SendRequest("create", new() { table, data }, cancellationToken).ConfigureAwait(false);
 
 		var list = dbResponse.GetValue<List<T>>() ?? new();
 		return list.First();
@@ -152,11 +152,11 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 
     public async Task Delete(string table, CancellationToken cancellationToken)
     {
-		await SendRequest("delete", new() { table }, cancellationToken);
+		await SendRequest("delete", new() { table }, cancellationToken).ConfigureAwait(false);
 	}
     public async Task<bool> Delete(Thing thing, CancellationToken cancellationToken)
 	{
-		var dbResponse = await SendRequest("delete", new() { thing.ToString() }, cancellationToken);
+		var dbResponse = await SendRequest("delete", new() { thing.ToString() }, cancellationToken).ConfigureAwait(false);
 
 		var valueKind = dbResponse.Result.ValueKind;
 		return valueKind != JsonValueKind.Null && valueKind != JsonValueKind.Undefined;
@@ -187,7 +187,7 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 
 		try
 		{
-			await _wsClient.StartOrFail();
+			await _wsClient.StartOrFail().ConfigureAwait(false);
 			return true;
 		}
 		catch (Exception)
@@ -198,7 +198,7 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 
 	public async Task Invalidate(CancellationToken cancellationToken)
 	{
-		await SendRequest("invalidate", null, cancellationToken);
+		await SendRequest("invalidate", null, cancellationToken).ConfigureAwait(false);
 	}
 
 	public async Task<TOutput> Merge<TMerge, TOutput>(TMerge data, CancellationToken cancellationToken) where TMerge : Record
@@ -206,12 +206,12 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 		if (data.Id is null)
 			throw new SurrealDbException("Cannot create a record without an Id");
 
-		var dbResponse = await SendRequest("merge", new() { data.Id.ToWsString(), data }, cancellationToken);
+		var dbResponse = await SendRequest("merge", new() { data.Id.ToWsString(), data }, cancellationToken).ConfigureAwait(false);
 		return dbResponse.GetValue<TOutput>()!;
 	}
 	public async Task<T> Merge<T>(Thing thing, Dictionary<string, object> data, CancellationToken cancellationToken)
 	{
-		var dbResponse = await SendRequest("merge", new() { thing.ToWsString(), data }, cancellationToken);
+		var dbResponse = await SendRequest("merge", new() { thing.ToWsString(), data }, cancellationToken).ConfigureAwait(false);
 		return dbResponse.GetValue<T>()!;
 	}
 
@@ -221,7 +221,7 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 		CancellationToken cancellationToken
 	)
 	{
-		var dbResponse = await SendRequest("query", new() { query, parameters }, cancellationToken);
+		var dbResponse = await SendRequest("query", new() { query, parameters }, cancellationToken).ConfigureAwait(false);
 
 		var list = dbResponse.GetValue<List<ISurrealDbResult>>() ?? new();
 		return new SurrealDbResponse(list);
@@ -229,41 +229,41 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 
     public async Task<List<T>> Select<T>(string table, CancellationToken cancellationToken)
 	{
-		var dbResponse = await SendRequest("select", new() { table }, cancellationToken);
+		var dbResponse = await SendRequest("select", new() { table }, cancellationToken).ConfigureAwait(false);
 		return dbResponse.GetValue<List<T>>()!;
 	}
     public async Task<T?> Select<T>(Thing thing, CancellationToken cancellationToken)
 	{
-		var dbResponse = await SendRequest("select", new() { thing.ToWsString() }, cancellationToken);
+		var dbResponse = await SendRequest("select", new() { thing.ToWsString() }, cancellationToken).ConfigureAwait(false);
 		return dbResponse.GetValue<T?>();
 	}
 
     public async Task Set(string key, object value, CancellationToken cancellationToken)
 	{
-		await SendRequest("let", new() { key, value }, cancellationToken);
+		await SendRequest("let", new() { key, value }, cancellationToken).ConfigureAwait(false);
 	}
 
     public async Task SignIn(RootAuth rootAuth, CancellationToken cancellationToken)
 	{
-		await SendRequest("signin", new() { rootAuth }, cancellationToken);
+		await SendRequest("signin", new() { rootAuth }, cancellationToken).ConfigureAwait(false);
 	}
 	public async Task<Jwt> SignIn(NamespaceAuth nsAuth, CancellationToken cancellationToken)
 	{
-		var dbResponse = await SendRequest("signin", new() { nsAuth }, cancellationToken);
+		var dbResponse = await SendRequest("signin", new() { nsAuth }, cancellationToken).ConfigureAwait(false);
 		var token = dbResponse.GetValue<string>()!;
 
 		return new Jwt { Token = token! };
 	}
 	public async Task<Jwt> SignIn(DatabaseAuth dbAuth, CancellationToken cancellationToken)
 	{
-		var dbResponse = await SendRequest("signin", new() { dbAuth }, cancellationToken);
+		var dbResponse = await SendRequest("signin", new() { dbAuth }, cancellationToken).ConfigureAwait(false);
 		var token = dbResponse.GetValue<string>()!;
 
 		return new Jwt { Token = token! };
 	}
 	public async Task<Jwt> SignIn<T>(T scopeAuth, CancellationToken cancellationToken) where T : ScopeAuth
 	{
-		var dbResponse = await SendRequest("signin", new() { scopeAuth }, cancellationToken);
+		var dbResponse = await SendRequest("signin", new() { scopeAuth }, cancellationToken).ConfigureAwait(false);
 		var token = dbResponse.GetValue<string>()!;
 
 		return new Jwt { Token = token! };
@@ -271,15 +271,15 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 
 	public async Task<Jwt> SignUp<T>(T scopeAuth, CancellationToken cancellationToken) where T : ScopeAuth
 	{
-		var dbResponse = await SendRequest("signup", new() { scopeAuth }, cancellationToken);
+		var dbResponse = await SendRequest("signup", new() { scopeAuth }, cancellationToken).ConfigureAwait(false);
 		var token = dbResponse.GetValue<string>()!;
 
 		return new Jwt { Token = token! };
 	}
 
-	public Task Unset(string key, CancellationToken cancellationToken)
+	public async Task Unset(string key, CancellationToken cancellationToken)
 	{
-		return SendRequest("unset", new() { key }, cancellationToken);
+		await SendRequest("unset", new() { key }, cancellationToken).ConfigureAwait(false);
 	}
 
 	public async Task<T> Upsert<T>(T data, CancellationToken cancellationToken) where T : Record
@@ -287,18 +287,18 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 		if (data.Id is null)
 			throw new SurrealDbException("Cannot create a record without an Id");
 
-		var dbResponse = await SendRequest("update", new() { data.Id.ToWsString(), data }, cancellationToken);
+		var dbResponse = await SendRequest("update", new() { data.Id.ToWsString(), data }, cancellationToken).ConfigureAwait(false);
 		return dbResponse.GetValue<T>()!;
 	}
 
 	public async Task Use(string ns, string db, CancellationToken cancellationToken)
     {
-		await SendRequest("use", new() { ns, db }, cancellationToken);
+		await SendRequest("use", new() { ns, db }, cancellationToken).ConfigureAwait(false);
 	}
 
 	public async Task<string> Version(CancellationToken cancellationToken)
 	{
-		var dbResponse = await SendRequest("version", null, cancellationToken);
+		var dbResponse = await SendRequest("version", null, cancellationToken).ConfigureAwait(false);
 		return dbResponse.GetValue<string>()!;
 	}
 
@@ -306,7 +306,7 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 	{
 		if (!_wsClient.IsStarted)
 		{
-			await Connect(cancellationToken);
+			await Connect(cancellationToken).ConfigureAwait(false);
 			cancellationToken.ThrowIfCancellationRequested();
 		}
 
@@ -330,14 +330,16 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 		};
 
 		using var stream = _memoryStreamManager.GetStream();
-		await JsonSerializer.SerializeAsync(stream, request, SurrealDbSerializerOptions.Default, cancellationToken);
+		await JsonSerializer
+			.SerializeAsync(stream, request, SurrealDbSerializerOptions.Default, cancellationToken)
+			.ConfigureAwait(false);
 		stream.Seek(0, SeekOrigin.Begin);
 		using var reader = new StreamReader(stream);
-		string payload = await reader.ReadToEndAsync();
+		string payload = await reader.ReadToEndAsync().ConfigureAwait(false);
 
 		_wsClient.Send(payload);
 
-		var response = await taskCompletionSource.Task;
+		var response = await taskCompletionSource.Task.ConfigureAwait(false);
 		cancellationToken.ThrowIfCancellationRequested();
 
 		return response;


### PR DESCRIPTION
* Add `ConfigureAwait(false)` on library async calls to handle proper multithreading and improve app responsiveness
* Update readme to disable logs on surrealdb client when running benchmark

Disabling logs does not really have an impact on HTTP benchmarks but have a huge impact on WS benchmarks, see below the updated benchmarks:

### Cold Start
| Method                | Mean        | Error    | StdDev   | Allocated |
|---------------------- |------------:|---------:|---------:|----------:|
| HttpConstructor       |    15.46 ms | 0.300 ms | 0.281 ms |  11.63 KB |
| HttpStaticConstructor |    15.78 ms | 0.310 ms | 0.369 ms |  11.89 KB |
| WsConstructor         | 2,054.91 ms | 8.055 ms | 7.534 ms |   81.8 KB |
| WsStaticConstructor   | 2,056.26 ms | 9.862 ms | 9.225 ms |   81.2 KB |

### Select
| Method                | Mean        | Error     | StdDev    | Gen0   | Allocated |
|---------------------- |------------:|----------:|----------:|-------:|----------:|
| Http                  | 14,851.8 μs | 256.04 μs | 239.50 μs |      - |  13.29 KB |
| HttpWithClientFactory | 14,453.1 μs |  77.40 μs |  72.40 μs |      - |  12.23 KB |
| WsText                |    168.6 μs |   1.18 μs |   1.05 μs | 0.7324 |   12.9 KB |

### Create
| Method                | Mean        | Error    | StdDev   | Gen0   | Allocated |
|---------------------- |------------:|---------:|---------:|-------:|----------:|
| Http                  | 15,205.5 μs | 54.96 μs | 51.41 μs |      - |  54.44 KB |
| HttpWithClientFactory | 15,107.9 μs | 47.69 μs | 39.83 μs |      - |   54.5 KB |
| WsText                |    288.7 μs |  2.52 μs |  2.35 μs | 3.4180 |  55.41 KB |

### Upsert
| Method                | Mean        | Error     | StdDev   | Gen0   | Allocated |
|---------------------- |------------:|----------:|---------:|-------:|----------:|
| Http                  | 14,610.2 μs |  74.79 μs | 66.30 μs |      - |  26.95 KB |
| HttpWithClientFactory | 14,616.3 μs | 103.86 μs | 97.15 μs |      - |  27.97 KB |
| WsText                |    242.2 μs |   1.85 μs |  1.73 μs | 1.4648 |  27.21 KB |

### Delete
| Method                | Mean        | Error    | StdDev   | Median      | Gen0   | Allocated |
|---------------------- |------------:|---------:|---------:|------------:|-------:|----------:|
| Http                  | 15,003.5 μs | 90.43 μs | 84.59 μs | 15,011.9 μs |      - |    8.4 KB |
| HttpWithClientFactory | 14,923.0 μs | 39.13 μs | 36.60 μs | 14,915.8 μs |      - |  10.14 KB |
| WsText                |    177.1 μs |  4.26 μs | 12.55 μs |    181.2 μs | 0.2441 |   7.75 KB |

### Query
| Method                | Mean        | Error    | StdDev   | Gen0   | Allocated |
|---------------------- |------------:|---------:|---------:|-------:|----------:|
| Http                  | 14,961.2 μs | 67.05 μs | 59.44 μs |      - |   15.6 KB |
| HttpWithClientFactory | 14,961.0 μs | 76.29 μs | 71.36 μs |      - |  18.92 KB |
| WsText                |    263.8 μs |  2.01 μs |  1.78 μs | 1.4648 |  24.39 KB |

### Scenario
| Method                | Mean       | Error     | StdDev    | Gen0   | Allocated |
|---------------------- |-----------:|----------:|----------:|-------:|----------:|
| Http                  | 185.736 ms | 3.5979 ms | 3.5337 ms |      - | 173.95 KB |
| HttpWithClientFactory | 186.306 ms | 1.5895 ms | 1.4868 ms |      - | 198.79 KB |
| WsText                |   3.117 ms | 0.0153 ms | 0.0135 ms | 7.8125 | 167.57 KB |