### PR TITLE
Feature/fix id in route attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ public class WeatherForecastController : ControllerBase
 	}
 
 	[HttpGet]
-	[Route("/:id")]
+	[Route("/{id}")]
 	public async Task<IActionResult> Get(string id, CancellationToken cancellationToken)
 	{
 		var weatherForecast = await _surrealDbClient.Select<WeatherForecast>(Table, id, cancellationToken);
@@ -199,7 +199,7 @@ public class WeatherForecastController : ControllerBase
 	}
 
 	[HttpPatch]
-	[Route("/:id")]
+	[Route("/{id}")]
 	public Task<WeatherForecast> Patch(string id, Dictionary<string, object> data, CancellationToken cancellationToken)
 	{
 		var thing = new Thing(Table, id);
@@ -215,7 +215,7 @@ public class WeatherForecastController : ControllerBase
 	}
 
 	[HttpDelete]
-	[Route("/:id")]
+	[Route("/{id}")]
 	public async Task<IActionResult> Delete(string id, CancellationToken cancellationToken)
 	{
 		bool success = await _surrealDbClient.Delete(Table, id, cancellationToken);

--- a/SurrealDb.Examples.WeatherApi/Controllers/WeatherForecastController.cs
+++ b/SurrealDb.Examples.WeatherApi/Controllers/WeatherForecastController.cs
@@ -38,7 +38,7 @@ public class WeatherForecastController : ControllerBase
 	/// Get a weather forecast by id.
 	/// </summary>
 	[HttpGet]
-	[Route("/:id")]
+	[Route("/:{id}")]
 	public async Task<IActionResult> Get(string id, CancellationToken cancellationToken)
 	{
 		var weatherForecast = await _surrealDbClient.Select<WeatherForecast>(Table, id, cancellationToken);
@@ -81,7 +81,7 @@ public class WeatherForecastController : ControllerBase
 	/// Patches an existing weather forecast.
 	/// </summary>
 	[HttpPatch]
-	[Route("/:id")]
+	[Route("/:{id}")]
 	public Task<WeatherForecast> Patch(string id, Dictionary<string, object> data, CancellationToken cancellationToken)
 	{
 		var thing = new Thing(Table, id);
@@ -103,7 +103,7 @@ public class WeatherForecastController : ControllerBase
 	/// Deletes a weather forecast by id.
 	/// </summary>
 	[HttpDelete]
-	[Route("/:id")]
+	[Route("/:{id}")]
 	public async Task<IActionResult> Delete(string id, CancellationToken cancellationToken)
 	{
 		bool success = await _surrealDbClient.Delete(Table, id, cancellationToken);

--- a/SurrealDb.Examples.WeatherApi/Controllers/WeatherForecastController.cs
+++ b/SurrealDb.Examples.WeatherApi/Controllers/WeatherForecastController.cs
@@ -38,7 +38,7 @@ public class WeatherForecastController : ControllerBase
 	/// Get a weather forecast by id.
 	/// </summary>
 	[HttpGet]
-	[Route("/:{id}")]
+	[Route("/{id}")]
 	public async Task<IActionResult> Get(string id, CancellationToken cancellationToken)
 	{
 		var weatherForecast = await _surrealDbClient.Select<WeatherForecast>(Table, id, cancellationToken);
@@ -81,7 +81,7 @@ public class WeatherForecastController : ControllerBase
 	/// Patches an existing weather forecast.
 	/// </summary>
 	[HttpPatch]
-	[Route("/:{id}")]
+	[Route("/{id}")]
 	public Task<WeatherForecast> Patch(string id, Dictionary<string, object> data, CancellationToken cancellationToken)
 	{
 		var thing = new Thing(Table, id);
@@ -103,7 +103,7 @@ public class WeatherForecastController : ControllerBase
 	/// Deletes a weather forecast by id.
 	/// </summary>
 	[HttpDelete]
-	[Route("/:{id}")]
+	[Route("/{id}")]
 	public async Task<IActionResult> Delete(string id, CancellationToken cancellationToken)
 	{
 		bool success = await _surrealDbClient.Delete(Table, id, cancellationToken);


### PR DESCRIPTION
When I was playing around with the client, I noticed a silly mistake in a `RouteAttribute` with `id` path parameter.
The correct format for a route is `[Route("/{id}")]` (the previous version was not catching the parameter `[Route("/:id")]`).

Another option would be to merge the `GetAll` and `Get` methods by applying the `?` syntax for optional parameters.
```csharp
[HttpGet]  
[Route("/")]  
[Route("/{id?}")]  
public Task<List<WeatherForecast>> GetAll(string? id, CancellationToken cancellationToken)
{
	// ...
}
```
However, for the sake of a clearer example, I would not do that :)