### PR TITLE
Add `MergeAll` and `UpdateAll` methods

### DIFF
--- a/SurrealDb.Net.Tests/MergeAllTests.cs
+++ b/SurrealDb.Net.Tests/MergeAllTests.cs
@@ -9,7 +9,7 @@ public class MergeAllTests
     [InlineData("ws://localhost:8000/rpc")]
     public async Task ShouldMergeAllRecords(string url)
     {
-        List<Post>? list = null;
+        IEnumerable<Post>? list = null;
         IEnumerable<Post>? results = null;
 
         Func<Task> func = async () =>
@@ -61,7 +61,7 @@ public class MergeAllTests
     [InlineData("ws://localhost:8000/rpc")]
     public async Task ShouldMergeAllRecordsUsingDictionary(string url)
     {
-        List<Post>? list = null;
+        IEnumerable<Post>? list = null;
         IEnumerable<Post>? results = null;
 
         Func<Task> func = async () =>

--- a/SurrealDb.Net.Tests/UpdateAllTests.cs
+++ b/SurrealDb.Net.Tests/UpdateAllTests.cs
@@ -1,0 +1,68 @@
+﻿using System.Text;
+
+namespace SurrealDb.Net.Tests;
+
+public class UpdateAllTests
+{
+    [Theory]
+    [InlineData("http://localhost:8000")]
+    [InlineData("ws://localhost:8000/rpc")]
+    public async Task ShouldUpdateAllRecords(string url)
+    {
+        List<Post>? list = null;
+        IEnumerable<Post>? results = null;
+
+        var now = DateTime.UtcNow;
+
+        Func<Task> func = async () =>
+        {
+            await using var surrealDbClientGenerator = new SurrealDbClientGenerator();
+            var dbInfo = surrealDbClientGenerator.GenerateDatabaseInfo();
+
+            string filePath = Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory,
+                "Schemas/post.surql"
+            );
+            string fileContent = File.ReadAllText(filePath, Encoding.UTF8);
+
+            string query = fileContent;
+
+            using var client = surrealDbClientGenerator.Create(url);
+            await client.SignIn(new RootAuth { Username = "root", Password = "root" });
+            await client.Use(dbInfo.Namespace, dbInfo.Database);
+            await client.Query(query);
+
+            var postUpdate = new Post
+            {
+                Title = "# Title",
+                Content = "# Content",
+                CreatedAt = now,
+                Status = "PUBLISHED"
+            };
+
+            list = await client.Select<Post>("post");
+
+            results = await client.UpdateAll("post", postUpdate);
+        };
+
+        await func.Should().NotThrowAsync();
+
+        list.Should().NotBeNull().And.HaveCount(2);
+
+        results.Should().NotBeNull();
+
+        var expected = list!.Select(
+            item =>
+                new Post
+                {
+                    Id = item.Id,
+                    Title = "# Title",
+                    Content = "# Content",
+                    CreatedAt = now,
+                    Status = "PUBLISHED",
+                }
+        );
+
+        results.Should().BeEquivalentTo(expected);
+    }
+}

--- a/SurrealDb.Net.Tests/UpdateAllTests.cs
+++ b/SurrealDb.Net.Tests/UpdateAllTests.cs
@@ -9,7 +9,7 @@ public class UpdateAllTests
     [InlineData("ws://localhost:8000/rpc")]
     public async Task ShouldUpdateAllRecords(string url)
     {
-        List<Post>? list = null;
+        IEnumerable<Post>? list = null;
         IEnumerable<Post>? results = null;
 
         var now = DateTime.UtcNow;

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Http.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Http.cs
@@ -484,6 +484,26 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
         return Task.CompletedTask;
     }
 
+    public async Task<IEnumerable<T>> UpdateAll<T>(
+        string table,
+        T data,
+        CancellationToken cancellationToken
+    )
+        where T : class
+    {
+        using var wrapper = CreateHttpClientWrapper();
+        using var body = CreateBodyContent(data);
+
+        using var response = await wrapper.Instance
+            .PutAsync($"/key/{table}", body, cancellationToken)
+            .ConfigureAwait(false);
+
+        var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken)
+            .ConfigureAwait(false);
+
+        return ExtractFirstResultValue<List<T>>(dbResponse)!; // TODO : .DeserializeEnumerable<T>
+    }
+
     public async Task<T> Upsert<T>(T data, CancellationToken cancellationToken)
         where T : Record
     {

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Http.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Http.cs
@@ -284,7 +284,8 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
         var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken)
             .ConfigureAwait(false);
 
-        return ExtractFirstResultValue<List<TOutput>>(dbResponse)!; // TODO : .DeserializeEnumerable<T>
+        var okResult = EnsuresFirstResultOk(dbResponse);
+        return okResult.DeserializeEnumerable<TOutput>();
     }
 
     public async Task<IEnumerable<T>> MergeAll<T>(
@@ -303,7 +304,8 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
         var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken)
             .ConfigureAwait(false);
 
-        return ExtractFirstResultValue<List<T>>(dbResponse)!; // TODO : .DeserializeEnumerable<T>
+        var okResult = EnsuresFirstResultOk(dbResponse);
+        return okResult.DeserializeEnumerable<T>();
     }
 
     public async Task<SurrealDbResponse> Query(
@@ -501,7 +503,8 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
         var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken)
             .ConfigureAwait(false);
 
-        return ExtractFirstResultValue<List<T>>(dbResponse)!; // TODO : .DeserializeEnumerable<T>
+        var okResult = EnsuresFirstResultOk(dbResponse);
+        return okResult.DeserializeEnumerable<T>();
     }
 
     public async Task<T> Upsert<T>(T data, CancellationToken cancellationToken)

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Http.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Http.cs
@@ -267,6 +267,45 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
         return okResult.DeserializeEnumerable<T>().First();
     }
 
+    public async Task<IEnumerable<TOutput>> MergeAll<TMerge, TOutput>(
+        string table,
+        TMerge data,
+        CancellationToken cancellationToken
+    )
+        where TMerge : class
+    {
+        using var wrapper = CreateHttpClientWrapper();
+        using var body = CreateBodyContent(data);
+
+        using var response = await wrapper.Instance
+            .PatchAsync($"/key/{table}", body, cancellationToken)
+            .ConfigureAwait(false);
+
+        var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken)
+            .ConfigureAwait(false);
+
+        return ExtractFirstResultValue<List<TOutput>>(dbResponse)!; // TODO : .DeserializeEnumerable<T>
+    }
+
+    public async Task<IEnumerable<T>> MergeAll<T>(
+        string table,
+        Dictionary<string, object> data,
+        CancellationToken cancellationToken
+    )
+    {
+        using var wrapper = CreateHttpClientWrapper();
+        using var body = CreateBodyContent(data);
+
+        using var response = await wrapper.Instance
+            .PatchAsync($"/key/{table}", body, cancellationToken)
+            .ConfigureAwait(false);
+
+        var dbResponse = await DeserializeDbResponseAsync(response, cancellationToken)
+            .ConfigureAwait(false);
+
+        return ExtractFirstResultValue<List<T>>(dbResponse)!; // TODO : .DeserializeEnumerable<T>
+    }
+
     public async Task<SurrealDbResponse> Query(
         string query,
         IReadOnlyDictionary<string, object> parameters,

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Interface.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Interface.cs
@@ -71,6 +71,8 @@ internal interface ISurrealDbEngine : IDisposable
         where T : ScopeAuth;
     SurrealDbLiveQueryChannel SubscribeToLiveQuery(Guid id);
     Task Unset(string key, CancellationToken cancellationToken);
+    Task<IEnumerable<T>> UpdateAll<T>(string table, T data, CancellationToken cancellationToken)
+        where T : class;
     Task<T> Upsert<T>(T data, CancellationToken cancellationToken)
         where T : Record;
     Task Use(string ns, string db, CancellationToken cancellationToken);

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Interface.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Interface.cs
@@ -43,6 +43,17 @@ internal interface ISurrealDbEngine : IDisposable
         Dictionary<string, object> data,
         CancellationToken cancellationToken
     );
+    Task<IEnumerable<TOutput>> MergeAll<TMerge, TOutput>(
+        string table,
+        TMerge data,
+        CancellationToken cancellationToken
+    )
+        where TMerge : class;
+    Task<IEnumerable<T>> MergeAll<T>(
+        string table,
+        Dictionary<string, object> data,
+        CancellationToken cancellationToken
+    );
     Task<SurrealDbResponse> Query(
         string query,
         IReadOnlyDictionary<string, object> parameters,

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
@@ -421,6 +421,29 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         return dbResponse.GetValue<T>()!;
     }
 
+    public async Task<IEnumerable<TOutput>> MergeAll<TMerge, TOutput>(
+        string table,
+        TMerge data,
+        CancellationToken cancellationToken
+    )
+        where TMerge : class
+    {
+        var dbResponse = await SendRequest("merge", new() { table, data }, cancellationToken)
+            .ConfigureAwait(false);
+        return dbResponse.GetValue<List<TOutput>>()!; // TODO : .DeserializeEnumerable<T>
+    }
+
+    public async Task<IEnumerable<T>> MergeAll<T>(
+        string table,
+        Dictionary<string, object> data,
+        CancellationToken cancellationToken
+    )
+    {
+        var dbResponse = await SendRequest("merge", new() { table, data }, cancellationToken)
+            .ConfigureAwait(false);
+        return dbResponse.GetValue<List<T>>()!; // TODO : .DeserializeEnumerable<T>
+    }
+
     public async Task<SurrealDbResponse> Query(
         string query,
         IReadOnlyDictionary<string, object> parameters,

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
@@ -430,7 +430,7 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     {
         var dbResponse = await SendRequest("merge", new() { table, data }, cancellationToken)
             .ConfigureAwait(false);
-        return dbResponse.GetValue<List<TOutput>>()!; // TODO : .DeserializeEnumerable<T>
+        return dbResponse.DeserializeEnumerable<TOutput>();
     }
 
     public async Task<IEnumerable<T>> MergeAll<T>(
@@ -441,7 +441,7 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     {
         var dbResponse = await SendRequest("merge", new() { table, data }, cancellationToken)
             .ConfigureAwait(false);
-        return dbResponse.GetValue<List<T>>()!; // TODO : .DeserializeEnumerable<T>
+        return dbResponse.DeserializeEnumerable<T>();
     }
 
     public async Task<SurrealDbResponse> Query(
@@ -555,7 +555,7 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     {
         var dbResponse = await SendRequest("update", new() { table, data }, cancellationToken)
             .ConfigureAwait(false);
-        return dbResponse.GetValue<List<T>>()!; // TODO : .DeserializeEnumerable<T>
+        return dbResponse.DeserializeEnumerable<T>();
     }
 
     public async Task<T> Upsert<T>(T data, CancellationToken cancellationToken)

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
@@ -546,6 +546,18 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         await SendRequest("unset", new() { key }, cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task<IEnumerable<T>> UpdateAll<T>(
+        string table,
+        T data,
+        CancellationToken cancellationToken
+    )
+        where T : class
+    {
+        var dbResponse = await SendRequest("update", new() { table, data }, cancellationToken)
+            .ConfigureAwait(false);
+        return dbResponse.GetValue<List<T>>()!; // TODO : .DeserializeEnumerable<T>
+    }
+
     public async Task<T> Upsert<T>(T data, CancellationToken cancellationToken)
         where T : Record
     {

--- a/SurrealDb.Net/SurrealDbClient.Interface.cs
+++ b/SurrealDb.Net/SurrealDbClient.Interface.cs
@@ -433,6 +433,25 @@ public interface ISurrealDbClient : IDisposable
     Task Unset(string key, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Updates all records in the database.
+    /// </summary>
+    /// <typeparam name="T">The type of the record to create.</typeparam>
+    /// <param name="table">The name of the database table.</param>
+    /// <param name="data">The record to create or update.</param>
+    /// <param name="cancellationToken">The cancellationToken enables graceful cancellation of asynchronous operations</param>
+    /// <returns>The list of updated records.</returns>
+    /// <exception cref="OperationCanceledException"></exception>
+    /// <exception cref="HttpRequestException"></exception>
+    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="SurrealDbException"></exception>
+    Task<IEnumerable<T>> UpdateAll<T>(
+        string table,
+        T data,
+        CancellationToken cancellationToken = default
+    )
+        where T : class;
+
+    /// <summary>
     /// Updates or creates the specified record in the database.
     /// </summary>
     /// <typeparam name="T">The type of the record to create.</typeparam>

--- a/SurrealDb.Net/SurrealDbClient.Interface.cs
+++ b/SurrealDb.Net/SurrealDbClient.Interface.cs
@@ -254,6 +254,44 @@ public interface ISurrealDbClient : IDisposable
     );
 
     /// <summary>
+    /// Modifies all records in the database.
+    /// </summary>
+    /// <typeparam name="TMerge">The type of the merge update.</typeparam>
+    /// <typeparam name="TOutput">The type of the record updated.</typeparam>
+    /// <param name="table">The name of the database table.</param>
+    /// <param name="data">The data to merge with the current record.</param>
+    /// <param name="cancellationToken">The cancellationToken enables graceful cancellation of asynchronous operations</param>
+    /// <returns>The list of updated records.</returns>
+    /// <exception cref="OperationCanceledException"></exception>
+    /// <exception cref="HttpRequestException"></exception>
+    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="SurrealDbException"></exception>
+    Task<IEnumerable<TOutput>> MergeAll<TMerge, TOutput>(
+        string table,
+        TMerge data,
+        CancellationToken cancellationToken = default
+    )
+        where TMerge : class;
+
+    /// <summary>
+    /// Modifies all records in the database.
+    /// </summary>
+    /// <typeparam name="T">The type of the record updated.</typeparam>
+    /// <param name="table">The name of the database table.</param>
+    /// <param name="data">A list of key-value pairs that contains properties to change.</param>
+    /// <param name="cancellationToken">The cancellationToken enables graceful cancellation of asynchronous operations</param>
+    /// <returns>The list of updated records.</returns>
+    /// <exception cref="OperationCanceledException"></exception>
+    /// <exception cref="HttpRequestException"></exception>
+    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="SurrealDbException"></exception>
+    Task<IEnumerable<T>> MergeAll<T>(
+        string table,
+        Dictionary<string, object> data,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
     /// Executes custom SurrealQL queries.
     /// </summary>
     /// <param name="query">The SurrealQL query.</param>

--- a/SurrealDb.Net/SurrealDbClient.cs
+++ b/SurrealDb.Net/SurrealDbClient.cs
@@ -301,6 +301,16 @@ public class SurrealDbClient : ISurrealDbClient
         return _engine.Unset(key, cancellationToken);
     }
 
+    public Task<IEnumerable<T>> UpdateAll<T>(
+        string table,
+        T data,
+        CancellationToken cancellationToken = default
+    )
+        where T : class
+    {
+        return _engine.UpdateAll(table, data, cancellationToken);
+    }
+
     public Task<T> Upsert<T>(T data, CancellationToken cancellationToken = default)
         where T : Record
     {

--- a/SurrealDb.Net/SurrealDbClient.cs
+++ b/SurrealDb.Net/SurrealDbClient.cs
@@ -210,6 +210,25 @@ public class SurrealDbClient : ISurrealDbClient
         return _engine.Merge<T>(thing, data, cancellationToken);
     }
 
+    public Task<IEnumerable<TOutput>> MergeAll<TMerge, TOutput>(
+        string table,
+        TMerge data,
+        CancellationToken cancellationToken = default
+    )
+        where TMerge : class
+    {
+        return _engine.MergeAll<TMerge, TOutput>(table, data, cancellationToken);
+    }
+
+    public Task<IEnumerable<T>> MergeAll<T>(
+        string table,
+        Dictionary<string, object> data,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return _engine.MergeAll<T>(table, data, cancellationToken);
+    }
+
     public Task<SurrealDbResponse> Query(
         string query,
         IReadOnlyDictionary<string, object>? parameters = null,


### PR DESCRIPTION
* [x] Add `MergeAll` and `UpdateAll` methods to apply updates on all records of a table, both strategy "merge" or "update" (meaning replace)
* [x] With `All` suffix to prevent user mistake (no suffix = single mutation, with suffix = the entire table)
* [x] Update official doc

Depends on #46 