### PR TITLE
⚡️ replace Superpower parser by Pidgin

### DIFF
--- a/SurrealDb.Net.LocalBenchmarks/Models/DurationUnit.cs
+++ b/SurrealDb.Net.LocalBenchmarks/Models/DurationUnit.cs
@@ -1,0 +1,14 @@
+﻿namespace SurrealDb.Net.LocalBenchmarks.Models;
+
+public enum DurationUnit
+{
+    NanoSecond,
+    MicroSecond,
+    MilliSecond,
+    Second,
+    Minute,
+    Hour,
+    Day,
+    Week,
+    Year
+}

--- a/SurrealDb.Net.LocalBenchmarks/ParserBenchmark.cs
+++ b/SurrealDb.Net.LocalBenchmarks/ParserBenchmark.cs
@@ -14,16 +14,16 @@ public class ParserBenchmark
     [Benchmark]
     public Dictionary<DurationUnit, int> Superpower()
     {
-        return SuperpowerDurationParser.Parser
-            .Parse(Param)
+        return SuperpowerDurationParser
+            .Parser.Parse(Param)
             .ToDictionary(kv => kv.unit, kv => kv.value);
     }
 
     [Benchmark]
     public Dictionary<DurationUnit, int> Pidgin()
     {
-        return PidginDurationParser.Parser
-            .ParseOrThrow(Param)
+        return PidginDurationParser
+            .Parser.ParseOrThrow(Param)
             .ToDictionary(kv => kv.unit, kv => kv.value);
     }
 }

--- a/SurrealDb.Net.LocalBenchmarks/ParserBenchmark.cs
+++ b/SurrealDb.Net.LocalBenchmarks/ParserBenchmark.cs
@@ -1,0 +1,29 @@
+﻿using BenchmarkDotNet.Attributes;
+using Pidgin;
+using Superpower;
+using SurrealDb.Net.LocalBenchmarks.Models;
+using SurrealDb.Net.LocalBenchmarks.Parsers;
+
+namespace SurrealDb.Net.LocalBenchmarks;
+
+public class ParserBenchmark
+{
+    [Params("0ns", "5y4w3h115ms4ns")]
+    public string Param = string.Empty;
+
+    [Benchmark]
+    public Dictionary<DurationUnit, int> Superpower()
+    {
+        return SuperpowerDurationParser.Parser
+            .Parse(Param)
+            .ToDictionary(kv => kv.unit, kv => kv.value);
+    }
+
+    [Benchmark]
+    public Dictionary<DurationUnit, int> Pidgin()
+    {
+        return PidginDurationParser.Parser
+            .ParseOrThrow(Param)
+            .ToDictionary(kv => kv.unit, kv => kv.value);
+    }
+}

--- a/SurrealDb.Net.LocalBenchmarks/Parsers/DurationParser.Pidgin.cs
+++ b/SurrealDb.Net.LocalBenchmarks/Parsers/DurationParser.Pidgin.cs
@@ -1,0 +1,28 @@
+﻿using Pidgin;
+using SurrealDb.Net.LocalBenchmarks.Models;
+using static Pidgin.Parser;
+
+namespace SurrealDb.Net.LocalBenchmarks.Parsers;
+
+internal static class PidginDurationParser
+{
+    public static readonly Parser<char, DurationUnit> DurationUnitParser = Try(
+            String("ns").Map(_ => DurationUnit.NanoSecond)
+        )
+        .Or(Try(String("µs").Or(String("us")).Map(_ => DurationUnit.MicroSecond)))
+        .Or(Try(String("ms").Map(_ => DurationUnit.MilliSecond)))
+        .Or(Try(String("s").Map(_ => DurationUnit.Second)))
+        .Or(Try(String("m").Map(_ => DurationUnit.Minute)))
+        .Or(Try(String("h").Map(_ => DurationUnit.Hour)))
+        .Or(Try(String("d").Map(_ => DurationUnit.Day)))
+        .Or(Try(String("w").Map(_ => DurationUnit.Week)))
+        .Or(Try(String("y").Map(_ => DurationUnit.Year)));
+
+    public static readonly Parser<char, (int value, DurationUnit unit)> DurationRaw =
+        from v in DecimalNum
+        from u in DurationUnitParser!
+        select (v, u);
+
+    public static readonly Parser<char, IEnumerable<(int value, DurationUnit unit)>> Parser =
+        DurationRaw.AtLeastOnce();
+}

--- a/SurrealDb.Net.LocalBenchmarks/Parsers/DurationParser.Superpower.cs
+++ b/SurrealDb.Net.LocalBenchmarks/Parsers/DurationParser.Superpower.cs
@@ -1,0 +1,37 @@
+﻿using Superpower;
+using Superpower.Parsers;
+using SurrealDb.Net.LocalBenchmarks.Models;
+
+namespace SurrealDb.Net.LocalBenchmarks.Parsers;
+
+internal static class SuperpowerDurationParser
+{
+    public static readonly TextParser<DurationUnit> DurationUnitParser = Span.EqualTo("ns")
+        .Value(DurationUnit.NanoSecond)
+        .Try()
+        .Or(Span.EqualTo("µs").Value(DurationUnit.MicroSecond))
+        .Try()
+        .Or(Span.EqualTo("us").Value(DurationUnit.MicroSecond))
+        .Try()
+        .Or(Span.EqualTo("ms").Value(DurationUnit.MilliSecond))
+        .Try()
+        .Or(Span.EqualTo("s").Value(DurationUnit.Second))
+        .Try()
+        .Or(Span.EqualTo("m").Value(DurationUnit.Minute))
+        .Try()
+        .Or(Span.EqualTo("h").Value(DurationUnit.Hour))
+        .Try()
+        .Or(Span.EqualTo("d").Value(DurationUnit.Day))
+        .Try()
+        .Or(Span.EqualTo("w").Value(DurationUnit.Week))
+        .Try()
+        .Or(Span.EqualTo("y").Value(DurationUnit.Year));
+
+    public static readonly TextParser<(int value, DurationUnit unit)> DurationRaw =
+        from v in Numerics.IntegerInt32
+        from u in DurationUnitParser!
+        select (v, u);
+
+    public static readonly TextParser<(int value, DurationUnit unit)[]> Parser =
+        DurationRaw.AtLeastOnce();
+}

--- a/SurrealDb.Net.LocalBenchmarks/SurrealDb.Net.LocalBenchmarks.csproj
+++ b/SurrealDb.Net.LocalBenchmarks/SurrealDb.Net.LocalBenchmarks.csproj
@@ -7,6 +7,12 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
+    <PackageReference Include="Pidgin" Version="3.2.3" />
+    <PackageReference Include="Superpower" Version="3.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SurrealDb.Net\SurrealDb.Net.csproj" />
   </ItemGroup>
 
 </Project>

--- a/SurrealDb.Net/Internals/Parsers/DateTimeParser.cs
+++ b/SurrealDb.Net/Internals/Parsers/DateTimeParser.cs
@@ -1,3 +1,111 @@
+﻿#if NET5_0_OR_GREATER
+using Pidgin;
+using SurrealDb.Net.Internals.Constants;
+using static Pidgin.Parser;
+
+namespace SurrealDb.Net.Internals.Parsers;
+
+internal static class DateTimeParser
+{
+    public static Parser<char, DateTime> Datetime =>
+        DatetimeWithDelimiters.Or(DatetimeWithoutDelimiters);
+
+    public static Parser<char, DateTime> DatetimeWithDelimiters =>
+        from openingQuote in SingleOrDoubleQuote
+        from datetime in DatetimeWithoutDelimiters
+        from closingQuote in Char(openingQuote)
+        select datetime;
+
+    public static Parser<char, DateTime> DatetimeWithoutDelimiters =>
+        DatetimeSingle.Or(DatetimeDouble);
+
+    public static Parser<char, char> SingleOrDoubleQuote = Char('\'').Or(Char('\"'));
+
+    public static Parser<char, DateTime> DatetimeSingle =>
+        from datetime in DatetimeRaw
+        select datetime;
+
+    public static Parser<char, DateTime> DatetimeDouble =>
+        from datetime in DatetimeRaw
+        select datetime;
+
+    public static Parser<char, DateTime> DatetimeRaw => Try(Nano).Or(Try(Time)).Or(Try(Date));
+
+    public static Parser<char, DateTime> Date =>
+        from year in Year
+        from _ in Char('-')
+        from month in Month
+        from __ in Char('-')
+        from day in Day
+        select new DateTime(year, month, day);
+
+    public static Parser<char, DateTime> Time =>
+        from year in Year
+        from _ in Char('-')
+        from month in Month
+        from __ in Char('-')
+        from day in Day
+        from ___ in Char('T')
+        from hour in Hour
+        from ____ in Char(':')
+        from minute in Minute
+        from _____ in Char(':')
+        from second in Second
+        from ______ in Zone
+        select new DateTime(year, month, day, hour, minute, second, DateTimeKind.Utc);
+
+    public static Parser<char, DateTime> Nano =>
+        from year in Year
+        from _ in Char('-')
+        from month in Month
+        from __ in Char('-')
+        from day in Day
+        from ___ in Char('T')
+        from hour in Hour
+        from ____ in Char(':')
+        from minute in Minute
+        from _____ in Char(':')
+        from second in Second
+        from ______ in Char('.')
+        from nano in TakeUntilDigit
+        from _______ in Zone
+        let nanoVal = nano.PadRight(9, '0')[..9]
+        let ticks = Math.Round(int.Parse(nanoVal) * TimeConstants.TicksPerNanosecond)
+        select new DateTime(year, month, day, hour, minute, second, DateTimeKind.Utc).AddTicks(
+            (long)ticks
+        );
+
+    public static Parser<char, int> Year =>
+        from s in Sign
+        from y in DecimalNum
+        select s.GetValueOrDefault(1) * y;
+
+    public static Parser<char, int> Month => from m in DecimalNum where m >= 1 && m <= 12 select m;
+
+    public static Parser<char, int> Day => from d in DecimalNum where d >= 1 && d <= 31 select d;
+
+    public static Parser<char, int> Hour => from h in DecimalNum where h >= 0 && h <= 23 select h;
+
+    public static Parser<char, int> Minute => from m in DecimalNum where m >= 0 && m <= 59 select m;
+
+    public static Parser<char, int> Second => from s in DecimalNum where s >= 0 && s <= 60 select s;
+
+    public static Parser<char, TimeZoneInfo> Zone => ZoneUtc;
+
+    public static Parser<char, TimeZoneInfo> ZoneUtc => Char('Z').Map(_ => TimeZoneInfo.Utc);
+
+    public static Parser<char, Maybe<int>> Sign =>
+        Char('-').Map(_ => -1).Or(Char('+').Map(_ => 1)).Optional();
+
+    public static Parser<char, string> TakeUntilDigit =>
+        Digit.AtLeastOnce().Select(chars => new string(chars.ToArray()));
+
+    public static DateTime Parse(string input)
+    {
+        return Datetime.ParseOrThrow(input);
+    }
+}
+#else
 using Superpower;
 using Superpower.Parsers;
 using SurrealDb.Net.Internals.Constants;
@@ -121,3 +229,4 @@ internal static class DateTimeParser
         return Datetime.Parse(input);
     }
 }
+#endif

--- a/SurrealDb.Net/Internals/Parsers/TimeSpanParser.cs
+++ b/SurrealDb.Net/Internals/Parsers/TimeSpanParser.cs
@@ -1,3 +1,45 @@
+﻿#if NET5_0_OR_GREATER
+using Pidgin;
+using SurrealDb.Net.Internals.Constants;
+using SurrealDb.Net.Internals.Models;
+
+namespace SurrealDb.Net.Internals.Parsers;
+
+internal static class TimeSpanParser
+{
+    private static TimeSpan ToTimeSpan(double value, DurationUnit unit)
+    {
+        return unit switch
+        {
+            DurationUnit.NanoSecond
+                => TimeSpan.FromTicks((long)Math.Round(value * TimeConstants.TicksPerNanosecond)),
+            DurationUnit.MicroSecond
+                => TimeSpan.FromTicks((long)(value * TimeConstants.TicksPerMicrosecond)),
+            DurationUnit.MilliSecond => TimeSpan.FromMilliseconds(value),
+            DurationUnit.Second => TimeSpan.FromSeconds(value),
+            DurationUnit.Minute => TimeSpan.FromMinutes(value),
+            DurationUnit.Hour => TimeSpan.FromHours(value),
+            DurationUnit.Day => TimeSpan.FromDays(value),
+            DurationUnit.Week => TimeSpan.FromDays(value * 7),
+            DurationUnit.Year => TimeSpan.FromDays(value * 365),
+            _ => throw new ArgumentException($"Invalid duration unit: {unit}")
+        };
+    }
+
+    public static readonly Parser<char, TimeSpan> DurationAsTimeSpanRaw =
+        from pair in DurationParser.DurationRaw
+        select ToTimeSpan(pair.value, pair.unit);
+
+    private static readonly Parser<char, IEnumerable<TimeSpan>> DurationAsTimeSpanParser =
+        DurationAsTimeSpanRaw.AtLeastOnce();
+
+    public static TimeSpan Parse(string input)
+    {
+        var result = DurationAsTimeSpanParser.ParseOrThrow(input);
+        return result.Aggregate(TimeSpan.Zero, (acc, span) => acc + span);
+    }
+}
+#else
 using Superpower;
 using SurrealDb.Net.Internals.Constants;
 using SurrealDb.Net.Internals.Models;
@@ -6,23 +48,21 @@ namespace SurrealDb.Net.Internals.Parsers;
 
 internal static class TimeSpanParser
 {
-    private static TimeSpan ToTimeSpan(decimal value, DurationUnit unit)
+    private static TimeSpan ToTimeSpan(double value, DurationUnit unit)
     {
         return unit switch
         {
             DurationUnit.NanoSecond
-                => TimeSpan.FromTicks(
-                    (long)Math.Round((double)value * TimeConstants.TicksPerNanosecond)
-                ),
+                => TimeSpan.FromTicks((long)Math.Round(value * TimeConstants.TicksPerNanosecond)),
             DurationUnit.MicroSecond
                 => TimeSpan.FromTicks((long)(value * TimeConstants.TicksPerMicrosecond)),
-            DurationUnit.MilliSecond => TimeSpan.FromMilliseconds((double)value),
-            DurationUnit.Second => TimeSpan.FromSeconds((double)value),
-            DurationUnit.Minute => TimeSpan.FromMinutes((double)value),
-            DurationUnit.Hour => TimeSpan.FromHours((double)value),
-            DurationUnit.Day => TimeSpan.FromDays((double)value),
-            DurationUnit.Week => TimeSpan.FromDays((double)value * 7),
-            DurationUnit.Year => TimeSpan.FromDays((double)value * 365),
+            DurationUnit.MilliSecond => TimeSpan.FromMilliseconds(value),
+            DurationUnit.Second => TimeSpan.FromSeconds(value),
+            DurationUnit.Minute => TimeSpan.FromMinutes(value),
+            DurationUnit.Hour => TimeSpan.FromHours(value),
+            DurationUnit.Day => TimeSpan.FromDays(value),
+            DurationUnit.Week => TimeSpan.FromDays(value * 7),
+            DurationUnit.Year => TimeSpan.FromDays(value * 365),
             _ => throw new ArgumentException($"Invalid duration unit: {unit}")
         };
     }
@@ -40,3 +80,4 @@ internal static class TimeSpanParser
         return result.Aggregate(TimeSpan.Zero, (acc, span) => acc + span);
     }
 }
+#endif

--- a/SurrealDb.Net/Models/Duration.Constructors.cs
+++ b/SurrealDb.Net/Models/Duration.Constructors.cs
@@ -1,5 +1,4 @@
-using Superpower;
-using SurrealDb.Net.Internals.Constants;
+﻿using SurrealDb.Net.Internals.Constants;
 using SurrealDb.Net.Internals.Parsers;
 
 namespace SurrealDb.Net.Models;
@@ -19,7 +18,7 @@ public readonly partial struct Duration
     {
         _value = value;
         _unitValues = DurationParser
-            .Parser.Parse(value)
+            .Parse(value)
             .Where(kv => kv.value != 0)
             .ToDictionary(kv => kv.unit, kv => (int)kv.value);
     }

--- a/SurrealDb.Net/SurrealDb.Net.csproj
+++ b/SurrealDb.Net/SurrealDb.Net.csproj
@@ -15,7 +15,6 @@
 	<PackageReference Include="Microsoft.Spatial" Version="7.18.0" />
 	<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	<PackageReference Include="Semver" Version="2.3.0" />
-	<PackageReference Include="Superpower" Version="3.0.0" />
 	<PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
 	<PackageReference Include="System.Text.Json" Version="8.0.0" />
 	<PackageReference Include="SystemTextJsonPatch" Version="3.0.1" />
@@ -35,6 +34,30 @@
 	<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
 	  <_Parameter1>SurrealDb.Reactive</_Parameter1>
 	</AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="Superpower">
+      <Version>3.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Pidgin">
+      <Version>3.2.3</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Pidgin">
+      <Version>3.2.3</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Pidgin">
+      <Version>3.2.3</Version>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Improve parsing performance by using Pidgin package instead of Superpower.

Performance benchmark on Duration parsing:

```
| Method     | Param          | Mean       | Error    | StdDev   | Gen0   | Allocated |
|----------- |--------------- |-----------:|---------:|---------:|-------:|----------:|
| Superpower | 0ns            |   479.2 ns |  2.27 ns |  2.01 ns | 0.0429 |     720 B |
| Pidgin     | 0ns            |   500.4 ns |  5.44 ns |  5.09 ns | 0.0191 |     320 B |
| Superpower | 5y4w3h115ms4ns | 3,405.1 ns | 12.95 ns | 11.48 ns | 0.1831 |    3072 B |
| Pidgin     | 5y4w3h115ms4ns | 2,645.1 ns | 52.15 ns | 48.78 ns | 0.0267 |     488 B |
```

* 40% faster (in general)
* Less memory allocation from an order of magnitude (2~3 times, up to 10+ times less memory allocation)