### PR TITLE
⚡️ add benchmark for DurationParser from int array vs. span

### DIFF
--- a/SurrealDb.Net.LocalBenchmarks/ParserBenchmark.cs
+++ b/SurrealDb.Net.LocalBenchmarks/ParserBenchmark.cs
@@ -24,7 +24,7 @@ public class ParserBenchmark
         };
     }
 
-    [Benchmark]
+    [Benchmark(Baseline = true)]
     public Dictionary<DurationUnit, int> Superpower()
     {
         return SuperpowerDurationParser
@@ -38,6 +38,12 @@ public class ParserBenchmark
         return PidginDurationParser
             .Parser.ParseOrThrow(Param)
             .ToDictionary(kv => kv.unit, kv => kv.value);
+    }
+
+    [Benchmark]
+    public Dictionary<DurationUnit, int> FromSpan()
+    {
+        return FromSpanDurationParser.Parse(Param);
     }
 
     [Benchmark]

--- a/SurrealDb.Net.LocalBenchmarks/ParserBenchmark.cs
+++ b/SurrealDb.Net.LocalBenchmarks/ParserBenchmark.cs
@@ -11,6 +11,19 @@ public class ParserBenchmark
     [Params("0ns", "5y4w3h115ms4ns")]
     public string Param = string.Empty;
 
+    private (long? Seconds, int? Nanos) _paramAsArray = (null, null);
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _paramAsArray = Param switch
+        {
+            "0ns" => (null, null),
+            "5y4w3h115ms4ns" => (160_110_000, 115_000_004),
+            _ => throw new ArgumentOutOfRangeException(nameof(Param)),
+        };
+    }
+
     [Benchmark]
     public Dictionary<DurationUnit, int> Superpower()
     {
@@ -25,5 +38,11 @@ public class ParserBenchmark
         return PidginDurationParser
             .Parser.ParseOrThrow(Param)
             .ToDictionary(kv => kv.unit, kv => kv.value);
+    }
+
+    [Benchmark]
+    public Dictionary<DurationUnit, int> FromArray()
+    {
+        return FromArrayDurationParser.Parse(_paramAsArray.Seconds, _paramAsArray.Nanos);
     }
 }

--- a/SurrealDb.Net.LocalBenchmarks/Parsers/DurationParser.FromArray.cs
+++ b/SurrealDb.Net.LocalBenchmarks/Parsers/DurationParser.FromArray.cs
@@ -1,0 +1,92 @@
+﻿using SurrealDb.Net.LocalBenchmarks.Models;
+
+namespace SurrealDb.Net.LocalBenchmarks.Parsers;
+
+internal static class FromArrayDurationParser
+{
+    private const int SECONDS_PER_MINUTE = 60;
+    private const int SECONDS_PER_HOUR = 60 * SECONDS_PER_MINUTE;
+    private const int SECONDS_PER_DAY = 24 * SECONDS_PER_HOUR;
+    private const int SECONDS_PER_WEEK = 7 * SECONDS_PER_DAY;
+    private const int SECONDS_PER_YEAR = 52 * SECONDS_PER_WEEK;
+
+    private const int NANOS_PER_SECOND = 1_000_000_000;
+    private const int NANOS_PER_MILLISECOND = NANOS_PER_SECOND / 1000;
+    private const int NANOS_PER_MICROSECOND = NANOS_PER_MILLISECOND / 1000;
+
+    public static Dictionary<DurationUnit, int> Parse(long? seconds, int? nanos)
+    {
+        var value = new Dictionary<DurationUnit, int>();
+
+        if (seconds.HasValue)
+        {
+            long remainingSeconds = seconds.Value;
+
+            int years = (int)(remainingSeconds / SECONDS_PER_YEAR);
+            if (years != 0)
+            {
+                remainingSeconds -= years * SECONDS_PER_YEAR;
+                value.Add(DurationUnit.Year, years);
+            }
+
+            int weeks = (int)(remainingSeconds / SECONDS_PER_WEEK);
+            if (weeks != 0)
+            {
+                remainingSeconds -= weeks * SECONDS_PER_WEEK;
+                value.Add(DurationUnit.Week, weeks);
+            }
+
+            int days = (int)(remainingSeconds / SECONDS_PER_DAY);
+            if (days != 0)
+            {
+                remainingSeconds -= days * SECONDS_PER_DAY;
+                value.Add(DurationUnit.Day, days);
+            }
+
+            int hours = (int)(remainingSeconds / SECONDS_PER_HOUR);
+            if (hours != 0)
+            {
+                remainingSeconds -= hours * SECONDS_PER_HOUR;
+                value.Add(DurationUnit.Hour, hours);
+            }
+
+            int minutes = (int)(remainingSeconds / SECONDS_PER_MINUTE);
+            if (minutes != 0)
+            {
+                remainingSeconds -= minutes * SECONDS_PER_MINUTE;
+                value.Add(DurationUnit.Minute, minutes);
+            }
+
+            if (remainingSeconds != 0)
+            {
+                value.Add(DurationUnit.Second, (int)remainingSeconds);
+            }
+        }
+
+        if (nanos.HasValue)
+        {
+            int remainingNanos = nanos.Value;
+
+            int millis = remainingNanos / NANOS_PER_MILLISECOND;
+            if (millis != 0)
+            {
+                remainingNanos -= millis * NANOS_PER_MILLISECOND;
+                value.Add(DurationUnit.MilliSecond, millis);
+            }
+
+            int micros = remainingNanos / NANOS_PER_MICROSECOND;
+            if (micros != 0)
+            {
+                remainingNanos -= micros * NANOS_PER_MICROSECOND;
+                value.Add(DurationUnit.MicroSecond, micros);
+            }
+
+            if (remainingNanos != 0)
+            {
+                value.Add(DurationUnit.NanoSecond, remainingNanos);
+            }
+        }
+
+        return value;
+    }
+}

--- a/SurrealDb.Net.LocalBenchmarks/Parsers/DurationParser.FromSpan.cs
+++ b/SurrealDb.Net.LocalBenchmarks/Parsers/DurationParser.FromSpan.cs
@@ -1,0 +1,103 @@
+﻿using SurrealDb.Net.LocalBenchmarks.Models;
+
+namespace SurrealDb.Net.LocalBenchmarks.Parsers;
+
+internal static class FromSpanDurationParser
+{
+    public static Dictionary<DurationUnit, int> Parse(ReadOnlySpan<char> chars)
+    {
+        var result = new Dictionary<DurationUnit, int>();
+
+        Span<byte> valueBuffer =
+            chars.Length <= 128 ? stackalloc byte[chars.Length - 1] : new byte[chars.Length - 1];
+        Span<byte> unitBuffer = stackalloc byte[2];
+
+        int valueIndex = 0;
+        int unitIndex = 0;
+
+        bool lastIsUnit = false;
+
+        for (int index = 0; index < chars.Length; index++)
+        {
+            char c = chars[index];
+
+            if (char.IsDigit(c))
+            {
+                if (lastIsUnit)
+                {
+                    if (valueIndex > 0)
+                    {
+                        var value = int.Parse(valueBuffer[..valueIndex]);
+                        var unit = ExtractDurationUnit(unitBuffer, unitIndex);
+
+                        result.Add(unit, value);
+                    }
+
+                    lastIsUnit = false;
+                    valueIndex = 0;
+
+                    valueBuffer[valueIndex++] = (byte)c;
+                }
+                else
+                {
+                    valueBuffer[valueIndex++] = (byte)c;
+                }
+            }
+            else
+            {
+                if (index == 0)
+                {
+                    throw new Exception("Expected integer value");
+                }
+
+                if (lastIsUnit)
+                {
+                    unitBuffer[unitIndex++] = (byte)c;
+                }
+                else
+                {
+                    lastIsUnit = true;
+                    unitIndex = 0;
+                    unitBuffer[unitIndex++] = (byte)c;
+                }
+            }
+        }
+
+        if (valueIndex > 0)
+        {
+            var value = int.Parse(valueBuffer[..valueIndex]);
+            var unit = ExtractDurationUnit(unitBuffer, unitIndex);
+
+            result.Add(unit, value);
+        }
+
+        return result;
+    }
+
+    private static DurationUnit ExtractDurationUnit(ReadOnlySpan<byte> unitBuffer, int unitIndex)
+    {
+        return unitIndex switch
+        {
+            1
+                => unitBuffer[0] switch
+                {
+                    (byte)'y' => DurationUnit.Year,
+                    (byte)'w' => DurationUnit.Week,
+                    (byte)'d' => DurationUnit.Day,
+                    (byte)'h' => DurationUnit.Hour,
+                    (byte)'m' => DurationUnit.Minute,
+                    (byte)'s' => DurationUnit.Second,
+                    _ => throw new Exception("Invalid unit")
+                },
+            2 when unitBuffer[1] == (byte)'s'
+                => unitBuffer[0] switch
+                {
+                    (byte)'m' => DurationUnit.MilliSecond,
+                    (byte)'u' or (byte)'µ' => DurationUnit.MicroSecond,
+                    (byte)'n' => DurationUnit.NanoSecond,
+                    _ => throw new Exception("Invalid unit")
+                },
+            _ => throw new Exception("Invalid unit")
+        };
+    }
+}


### PR DESCRIPTION
Added 2 benchmarks method to parse Duration 

* one from a string (`ReadOnlySpan<char>`), avoiding complex parser
* one from a `[long?, int?]` array

Result:
* less memory allocation
* way faster (avoiding string parsing)
* best format = `[long?, int?]` array

```
| Method     | Param          | Mean         | Error      | StdDev     | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|----------- |--------------- |-------------:|-----------:|-----------:|------:|--------:|-------:|----------:|------------:|
| Superpower | 0ns            |   481.745 ns |  5.3422 ns |  4.4610 ns |  1.00 |    0.00 | 0.0429 |     720 B |        1.00 |
| Pidgin     | 0ns            |   518.948 ns |  5.8655 ns |  5.4865 ns |  1.08 |    0.02 | 0.0191 |     320 B |        0.44 |
| FromSpan   | 0ns            |    32.940 ns |  0.4281 ns |  0.3795 ns |  0.07 |    0.00 | 0.0114 |     192 B |        0.27 |
| FromArray  | 0ns            |     7.218 ns |  0.1512 ns |  0.1263 ns |  0.01 |    0.00 | 0.0048 |      80 B |        0.11 |
|            |                |              |            |            |       |         |        |           |       |
| Superpower | 5y4w3h115ms4ns | 3,410.964 ns | 29.3004 ns | 25.9740 ns |  1.00 |    0.00 | 0.1831 |    3072 B |        1.00 |
| Pidgin     | 5y4w3h115ms4ns | 2,536.325 ns | 18.6825 ns | 17.4756 ns |  0.74 |    0.01 | 0.0267 |     488 B |        0.16 |
| FromSpan   | 5y4w3h115ms4ns |   128.111 ns |  0.7486 ns |  0.6251 ns |  0.04 |    0.00 | 0.0229 |     384 B |        0.12 |
| FromArray  | 5y4w3h115ms4ns |    69.696 ns |  0.4898 ns |  0.4582 ns |  0.02 |    0.00 | 0.0229 |     384 B |        0.12 |
```