### PR TITLE
Upsert method with thing id arg

### DIFF
--- a/SurrealDb.Net/Internals/SurrealDbEngine.Interface.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Interface.cs
@@ -89,6 +89,7 @@ internal interface ISurrealDbEngine : IDisposable
         where T : class;
     Task<T> Upsert<T>(T data, CancellationToken cancellationToken)
         where T : Record;
+    Task<T> Upsert<T>(Thing id, T data, CancellationToken cancellationToken);
     Task Use(string ns, string db, CancellationToken cancellationToken);
     Task<string> Version(CancellationToken cancellationToken);
 }

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Net.WebSockets;
@@ -804,15 +804,23 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         return dbResponse.DeserializeEnumerable<T>();
     }
 
-    public async Task<T> Upsert<T>(T data, CancellationToken cancellationToken)
+    public Task<T> Upsert<T>(T data, CancellationToken cancellationToken)
         where T : Record
     {
         if (data.Id is null)
             throw new SurrealDbException("Cannot create a record without an Id");
 
+        return Upsert(data.Id, data, cancellationToken);
+    }
+
+    public async Task<T> Upsert<T>(Thing id, T data, CancellationToken cancellationToken)
+    {
+        if (id is null)
+            throw new SurrealDbException("Cannot create a record without an Id");
+
         var dbResponse = await SendRequestAsync(
                 "update",
-                new() { data.Id.ToWsString(), data },
+                new() { id.ToWsString(), data },
                 true,
                 cancellationToken
             )

--- a/SurrealDb.Net/SurrealDbClient.Interface.cs
+++ b/SurrealDb.Net/SurrealDbClient.Interface.cs
@@ -512,6 +512,20 @@ public interface ISurrealDbClient : IDisposable
         where T : Record;
 
     /// <summary>
+    /// Updates or creates the specified record in the database.
+    /// </summary>
+    /// <typeparam name="T">The type of the data to create or update.</typeparam>
+    /// <param name="id">The id of the record.</param>
+    /// <param name="data">The date to create or update.</param>
+    /// <param name="cancellationToken">The cancellationToken enables graceful cancellation of asynchronous operations</param>
+    /// <returns>The record created or updated.</returns>
+    /// <exception cref="OperationCanceledException"></exception>
+    /// <exception cref="HttpRequestException"></exception>
+    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="SurrealDbException"></exception>
+    Task<T> Upsert<T>(Thing id, T data, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Switch to a specific namespace and database.
     /// </summary>
     /// <param name="ns">Name of the namespace</param>

--- a/SurrealDb.Net/SurrealDbClient.cs
+++ b/SurrealDb.Net/SurrealDbClient.cs
@@ -383,6 +383,11 @@ public class SurrealDbClient : ISurrealDbClient
         return _engine.Upsert(data, cancellationToken);
     }
 
+    public Task<T> Upsert<T>(Thing id, T data, CancellationToken cancellationToken = default)
+    {
+        return _engine.Upsert(id, data, cancellationToken);
+    }
+
     public Task Use(string ns, string db, CancellationToken cancellationToken = default)
     {
         return _engine.Use(ns, db, cancellationToken);


### PR DESCRIPTION
This PR adds a method for Upsert that accepts `T data` in addition to `Thing id`. The existing Upsert method now internally uses the new Upsert method.

`Task<T> Upsert<T>(Thing id, T data, CancellationToken cancellationToken)`

---

The reason behind this PR is that I am using Strong Typed IDs and cannot use the existing Upsert method. I have a `ToThing` method for each typed id.