### PR TITLE
♻️ simplify Duration struct

### DIFF
--- a/SurrealDb.Net.Tests/Models/Duration/ConstructorsDurationTests.cs
+++ b/SurrealDb.Net.Tests/Models/Duration/ConstructorsDurationTests.cs
@@ -1,11 +1,25 @@
-namespace SurrealDb.Net.Tests.Models;
+﻿namespace SurrealDb.Net.Tests.Models;
 
 public class ConstructorsDurationTests
 {
     [Fact]
-    public void NewDurationShouldBeEqualToZeroDuration()
+    public void ConstructDurationShouldBeEqualToZeroDuration()
     {
         bool result = new Duration() == Duration.Zero;
         result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ConstructDurationShouldFailWithUnauthorizedFloatingPointValue()
+    {
+        var action = () => new Duration("17.3ms");
+        action.Should().Throw<Exception>().WithMessage("Invalid unit");
+    }
+
+    [Fact]
+    public void ConstructDurationWithFloatingPointValue()
+    {
+        var result = new Duration("17.3ms", true);
+        result.MilliSeconds.Should().Be(17);
     }
 }

--- a/SurrealDb.Net/Internals/Cbor/Converters/DurationConverter.cs
+++ b/SurrealDb.Net/Internals/Cbor/Converters/DurationConverter.cs
@@ -19,8 +19,8 @@ internal class DurationConverter : CborConverterBase<Duration>
             throw new CborException("Expected a CBOR array with at most 2 elements");
         }
 
-        long? seconds = size >= 1 ? reader.ReadInt64() : null;
-        int? nanos = size >= 2 ? reader.ReadInt32() : null;
+        long seconds = size >= 1 ? reader.ReadInt64() : 0;
+        int nanos = size >= 2 ? reader.ReadInt32() : 0;
 
         return new Duration(seconds, nanos);
     }

--- a/SurrealDb.Net/Internals/Constants/DurationConstants.cs
+++ b/SurrealDb.Net/Internals/Constants/DurationConstants.cs
@@ -1,6 +1,0 @@
-namespace SurrealDb.Net.Internals.Constants;
-
-internal class DurationConstants
-{
-    public const string DefaultDuration = "0ns";
-}

--- a/SurrealDb.Net/Internals/Extensions/SpanExtensions.cs
+++ b/SurrealDb.Net/Internals/Extensions/SpanExtensions.cs
@@ -1,0 +1,39 @@
+﻿using System.Globalization;
+
+namespace SurrealDb.Net.Internals.Extensions;
+
+internal static class SpanExtensions
+{
+    public static void Write(this ref Span<char> buffer, ReadOnlySpan<char> value)
+    {
+        value.CopyTo(buffer);
+        buffer = buffer[value.Length..];
+    }
+
+    public static void Write(this ref Span<char> buffer, char value)
+    {
+        buffer[0] = value;
+        buffer = buffer[1..];
+    }
+
+    public static bool Write(
+        this ref Span<char> buffer,
+        int value,
+        IFormatProvider? provider = null
+    )
+    {
+        if (
+            value.TryFormat(
+                buffer,
+                out int charsWritten,
+                provider: provider ?? CultureInfo.InvariantCulture
+            )
+        )
+        {
+            buffer = buffer[charsWritten..];
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/SurrealDb.Net/Internals/Parsers/DurationParser.cs
+++ b/SurrealDb.Net/Internals/Parsers/DurationParser.cs
@@ -1,5 +1,4 @@
-﻿using SurrealDb.Net.Internals.Constants;
-using SurrealDb.Net.Internals.Models;
+﻿using SurrealDb.Net.Internals.Models;
 #if NET5_0_OR_GREATER
 using Pidgin;
 using static Pidgin.Parser;
@@ -10,87 +9,8 @@ using Superpower.Parsers;
 
 namespace SurrealDb.Net.Internals.Parsers;
 
-internal static partial class DurationParser
-{
-    public static Dictionary<DurationUnit, int> Convert(long? seconds, int? nanos)
-    {
-        var value = new Dictionary<DurationUnit, int>();
-
-        if (seconds.HasValue)
-        {
-            long remainingSeconds = seconds.Value;
-
-            int years = (int)(remainingSeconds / TimeConstants.SECONDS_PER_YEAR);
-            if (years != 0)
-            {
-                remainingSeconds -= years * TimeConstants.SECONDS_PER_YEAR;
-                value.Add(DurationUnit.Year, years);
-            }
-
-            int weeks = (int)(remainingSeconds / TimeConstants.SECONDS_PER_WEEK);
-            if (weeks != 0)
-            {
-                remainingSeconds -= weeks * TimeConstants.SECONDS_PER_WEEK;
-                value.Add(DurationUnit.Week, weeks);
-            }
-
-            int days = (int)(remainingSeconds / TimeConstants.SECONDS_PER_DAY);
-            if (days != 0)
-            {
-                remainingSeconds -= days * TimeConstants.SECONDS_PER_DAY;
-                value.Add(DurationUnit.Day, days);
-            }
-
-            int hours = (int)(remainingSeconds / TimeConstants.SECONDS_PER_HOUR);
-            if (hours != 0)
-            {
-                remainingSeconds -= hours * TimeConstants.SECONDS_PER_HOUR;
-                value.Add(DurationUnit.Hour, hours);
-            }
-
-            int minutes = (int)(remainingSeconds / TimeConstants.SECONDS_PER_MINUTE);
-            if (minutes != 0)
-            {
-                remainingSeconds -= minutes * TimeConstants.SECONDS_PER_MINUTE;
-                value.Add(DurationUnit.Minute, minutes);
-            }
-
-            if (remainingSeconds != 0)
-            {
-                value.Add(DurationUnit.Second, (int)remainingSeconds);
-            }
-        }
-
-        if (nanos.HasValue)
-        {
-            int remainingNanos = nanos.Value;
-
-            int millis = remainingNanos / TimeConstants.NANOS_PER_MILLISECOND;
-            if (millis != 0)
-            {
-                remainingNanos -= millis * TimeConstants.NANOS_PER_MILLISECOND;
-                value.Add(DurationUnit.MilliSecond, millis);
-            }
-
-            int micros = remainingNanos / TimeConstants.NANOS_PER_MICROSECOND;
-            if (micros != 0)
-            {
-                remainingNanos -= micros * TimeConstants.NANOS_PER_MICROSECOND;
-                value.Add(DurationUnit.MicroSecond, micros);
-            }
-
-            if (remainingNanos != 0)
-            {
-                value.Add(DurationUnit.NanoSecond, remainingNanos);
-            }
-        }
-
-        return value;
-    }
-}
-
 #if NET5_0_OR_GREATER
-internal static partial class DurationParser
+internal static class DurationParser
 {
     private static readonly Parser<char, DurationUnit> DurationUnitParser = Try(
             String("ns").Map(_ => DurationUnit.NanoSecond)
@@ -118,7 +38,7 @@ internal static partial class DurationParser
     }
 }
 #else
-internal static partial class DurationParser
+internal static class DurationParser
 {
     private static readonly TextParser<DurationUnit> DurationUnitParser = Span.EqualTo("ns")
         .Value(DurationUnit.NanoSecond)

--- a/SurrealDb.Net/Models/Duration.Constructors.cs
+++ b/SurrealDb.Net/Models/Duration.Constructors.cs
@@ -1,4 +1,5 @@
 ﻿using SurrealDb.Net.Internals.Constants;
+using SurrealDb.Net.Internals.Models;
 using SurrealDb.Net.Internals.Parsers;
 
 namespace SurrealDb.Net.Models;
@@ -6,26 +7,95 @@ namespace SurrealDb.Net.Models;
 public readonly partial struct Duration
 {
     /// <summary>
-    /// Creates a default Duration (0ns)
+    /// Creates a default <see cref="Duration"/>, equivalent to "0ns".
     /// </summary>
-    public Duration()
-    {
-        _value = DurationConstants.DefaultDuration;
-        _unitValues = new();
-    }
+    public Duration() { }
 
     internal Duration(string value)
     {
-        _value = value;
-        _unitValues = DurationParser
+        var unitValues = DurationParser
             .Parse(value)
             .Where(kv => kv.value != 0)
             .ToDictionary(kv => kv.unit, kv => (int)kv.value);
+
+        NanoSeconds = unitValues.GetValueOrDefault(DurationUnit.NanoSecond);
+        MicroSeconds = unitValues.GetValueOrDefault(DurationUnit.MicroSecond);
+        MilliSeconds = unitValues.GetValueOrDefault(DurationUnit.MilliSecond);
+        Seconds = unitValues.GetValueOrDefault(DurationUnit.Second);
+        Minutes = unitValues.GetValueOrDefault(DurationUnit.Minute);
+        Hours = unitValues.GetValueOrDefault(DurationUnit.Hour);
+        Days = unitValues.GetValueOrDefault(DurationUnit.Day);
+        Weeks = unitValues.GetValueOrDefault(DurationUnit.Week);
+        Years = unitValues.GetValueOrDefault(DurationUnit.Year);
     }
 
-    internal Duration(long? seconds, int? nanos)
+    /// <summary>
+    /// Creates a <see cref="Duration"/> from <paramref name="seconds"/> and <paramref name="nanoseconds"/> parts.
+    /// </summary>
+    /// <param name="seconds">The total number of seconds to store in this <see cref="Duration"/>. Defaults to 0.</param>
+    /// <param name="nanoseconds">The total number of nanoseconds to store in this <see cref="Duration"/>. Defaults to 0.</param>
+    public Duration(long seconds = 0, int nanoseconds = 0)
     {
-        _unitValues = DurationParser.Convert(seconds, nanos);
-        _value = ""; // TODO
+        if (seconds != 0)
+        {
+            long remainingSeconds = seconds;
+
+            Years = (int)(remainingSeconds / TimeConstants.SECONDS_PER_YEAR);
+            if (Years != 0)
+            {
+                remainingSeconds -= Years * TimeConstants.SECONDS_PER_YEAR;
+            }
+
+            Weeks = (int)(remainingSeconds / TimeConstants.SECONDS_PER_WEEK);
+            if (Weeks != 0)
+            {
+                remainingSeconds -= Weeks * TimeConstants.SECONDS_PER_WEEK;
+            }
+
+            Days = (int)(remainingSeconds / TimeConstants.SECONDS_PER_DAY);
+            if (Days != 0)
+            {
+                remainingSeconds -= Days * TimeConstants.SECONDS_PER_DAY;
+            }
+
+            Hours = (int)(remainingSeconds / TimeConstants.SECONDS_PER_HOUR);
+            if (Hours != 0)
+            {
+                remainingSeconds -= Hours * TimeConstants.SECONDS_PER_HOUR;
+            }
+
+            Minutes = (int)(remainingSeconds / TimeConstants.SECONDS_PER_MINUTE);
+            if (Minutes != 0)
+            {
+                remainingSeconds -= Minutes * TimeConstants.SECONDS_PER_MINUTE;
+            }
+
+            if (remainingSeconds != 0)
+            {
+                Seconds = (int)remainingSeconds;
+            }
+        }
+
+        if (nanoseconds != 0)
+        {
+            int remainingNanos = nanoseconds;
+
+            MilliSeconds = remainingNanos / TimeConstants.NANOS_PER_MILLISECOND;
+            if (MilliSeconds != 0)
+            {
+                remainingNanos -= MilliSeconds * TimeConstants.NANOS_PER_MILLISECOND;
+            }
+
+            MicroSeconds = remainingNanos / TimeConstants.NANOS_PER_MICROSECOND;
+            if (MicroSeconds != 0)
+            {
+                remainingNanos -= MicroSeconds * TimeConstants.NANOS_PER_MICROSECOND;
+            }
+
+            if (remainingNanos != 0)
+            {
+                NanoSeconds = remainingNanos;
+            }
+        }
     }
 }

--- a/SurrealDb.Net/Models/Duration.Properties.cs
+++ b/SurrealDb.Net/Models/Duration.Properties.cs
@@ -1,15 +1,7 @@
-using SurrealDb.Net.Internals.Models;
-
-namespace SurrealDb.Net.Models;
-
-// TODO : Avoid use of Dictionary<T>
-// TODO : Is value still necessary for CBOR?
+﻿namespace SurrealDb.Net.Models;
 
 public readonly partial struct Duration
 {
-    private readonly string? _value;
-    private readonly Dictionary<DurationUnit, int>? _unitValues = new();
-
     /// <summary>
     /// A Zero duration (equals to "0ns")
     /// </summary>
@@ -18,45 +10,45 @@ public readonly partial struct Duration
     /// <summary>
     /// The <see cref="NanoSeconds"/> part of the <see cref="Duration"/> type.
     /// </summary>
-    public int NanoSeconds => _unitValues?.GetValueOrDefault(DurationUnit.NanoSecond, 0) ?? 0;
+    public int NanoSeconds { get; }
 
     /// <summary>
     /// The <see cref="MicroSeconds"/> part of the <see cref="Duration"/> type.
     /// </summary>
-    public int MicroSeconds => _unitValues?.GetValueOrDefault(DurationUnit.MicroSecond, 0) ?? 0;
+    public int MicroSeconds { get; }
 
     /// <summary>
     /// The <see cref="MilliSeconds"/> part of the <see cref="Duration"/> type.
     /// </summary>
-    public int MilliSeconds => _unitValues?.GetValueOrDefault(DurationUnit.MilliSecond, 0) ?? 0;
+    public int MilliSeconds { get; }
 
     /// <summary>
     /// The <see cref="Seconds"/> part of the <see cref="Duration"/> type.
     /// </summary>
-    public int Seconds => _unitValues?.GetValueOrDefault(DurationUnit.Second, 0) ?? 0;
+    public int Seconds { get; }
 
     /// <summary>
     /// The <see cref="Minutes"/> part of the <see cref="Duration"/> type.
     /// </summary>
-    public int Minutes => _unitValues?.GetValueOrDefault(DurationUnit.Minute, 0) ?? 0;
+    public int Minutes { get; }
 
     /// <summary>
     /// The <see cref="Hours"/> part of the <see cref="Duration"/> type.
     /// </summary>
-    public int Hours => _unitValues?.GetValueOrDefault(DurationUnit.Hour, 0) ?? 0;
+    public int Hours { get; }
 
     /// <summary>
     /// The <see cref="Days"/> part of the <see cref="Duration"/> type.
     /// </summary>
-    public int Days => _unitValues?.GetValueOrDefault(DurationUnit.Day, 0) ?? 0;
+    public int Days { get; }
 
     /// <summary>
     /// The <see cref="Weeks"/> part of the <see cref="Duration"/> type.
     /// </summary>
-    public int Weeks => _unitValues?.GetValueOrDefault(DurationUnit.Week, 0) ?? 0;
+    public int Weeks { get; }
 
     /// <summary>
     /// The <see cref="Years"/> part of the <see cref="Duration"/> type.
     /// </summary>
-    public int Years => _unitValues?.GetValueOrDefault(DurationUnit.Year, 0) ?? 0;
+    public int Years { get; }
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What does this change do?

* Simplify the `Duration` struct to avoid the use of a `Dictionary`. 
* Fix issue with equality comparer due to the of a `Dictionary`
* Reduce memory allocation due to the removal of the `Dictionary`

## Is this related to any issues?

Unit tests

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)