### PR TITLE
✨ add and use StringRecordId type

### DIFF
--- a/SurrealDb.Embedded.InMemory/Internals/SurrealDbEngine.InMemory.cs
+++ b/SurrealDb.Embedded.InMemory/Internals/SurrealDbEngine.InMemory.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using System.Reactive;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Dahomey.Cbor;
 using SurrealDb.Net.Exceptions;
@@ -158,6 +159,17 @@ internal class SurrealDbInMemoryEngine : ISurrealDbInMemoryEngine
         return list.First();
     }
 
+    public async Task<TOutput> Create<TData, TOutput>(
+        StringRecordId recordId,
+        TData? data,
+        CancellationToken cancellationToken
+    )
+        where TOutput : Record
+    {
+        return await SendRequestAsync<TOutput>(Method.Create, [recordId, data], cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     public async Task Delete(string table, CancellationToken cancellationToken)
     {
         await SendRequestAsync<Unit>(Method.Delete, [table], cancellationToken)
@@ -167,6 +179,13 @@ internal class SurrealDbInMemoryEngine : ISurrealDbInMemoryEngine
     public async Task<bool> Delete(Thing thing, CancellationToken cancellationToken)
     {
         var result = await SendRequestAsync<object?>(Method.Delete, [thing], cancellationToken)
+            .ConfigureAwait(false);
+        return result is not null;
+    }
+
+    public async Task<bool> Delete(StringRecordId recordId, CancellationToken cancellationToken)
+    {
+        var result = await SendRequestAsync<object?>(Method.Delete, [recordId], cancellationToken)
             .ConfigureAwait(false);
         return result is not null;
     }
@@ -263,6 +282,16 @@ internal class SurrealDbInMemoryEngine : ISurrealDbInMemoryEngine
             .ConfigureAwait(false);
     }
 
+    public async Task<T> Merge<T>(
+        StringRecordId recordId,
+        Dictionary<string, object> data,
+        CancellationToken cancellationToken
+    )
+    {
+        return await SendRequestAsync<T>(Method.Merge, [recordId, data], cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     public async Task<IEnumerable<TOutput>> MergeAll<TMerge, TOutput>(
         string table,
         TMerge data,
@@ -300,6 +329,17 @@ internal class SurrealDbInMemoryEngine : ISurrealDbInMemoryEngine
         where T : class
     {
         return await SendRequestAsync<T>(Method.Patch, [thing, patches], cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<T> Patch<T>(
+        StringRecordId recordId,
+        JsonPatchDocument<T> patches,
+        CancellationToken cancellationToken
+    )
+        where T : class
+    {
+        return await SendRequestAsync<T>(Method.Patch, [recordId, patches], cancellationToken)
             .ConfigureAwait(false);
     }
 
@@ -388,6 +428,12 @@ internal class SurrealDbInMemoryEngine : ISurrealDbInMemoryEngine
             .ConfigureAwait(false);
     }
 
+    public async Task<T?> Select<T>(StringRecordId recordId, CancellationToken cancellationToken)
+    {
+        return await SendRequestAsync<T?>(Method.Select, [recordId], cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     public async Task Set(string key, object value, CancellationToken cancellationToken)
     {
         if (key is null)
@@ -471,6 +517,17 @@ internal class SurrealDbInMemoryEngine : ISurrealDbInMemoryEngine
             throw new SurrealDbException("Cannot create a record without an Id");
 
         return await SendRequestAsync<T>(Method.Update, [data.Id, data], cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<TOutput> Upsert<TData, TOutput>(
+        StringRecordId recordId,
+        TData data,
+        CancellationToken cancellationToken
+    )
+        where TOutput : Record
+    {
+        return await SendRequestAsync<TOutput>(Method.Update, [recordId, data], cancellationToken)
             .ConfigureAwait(false);
     }
 

--- a/SurrealDb.Embedded.InMemory/SurrealDbMemoryClient.cs
+++ b/SurrealDb.Embedded.InMemory/SurrealDbMemoryClient.cs
@@ -90,6 +90,16 @@ public class SurrealDbMemoryClient : ISurrealDbClient
         return _engine.Create(table, data, cancellationToken);
     }
 
+    public Task<TOutput> Create<TData, TOutput>(
+        StringRecordId recordId,
+        TData? data = default,
+        CancellationToken cancellationToken = default
+    )
+        where TOutput : Record
+    {
+        return _engine.Create<TData, TOutput>(recordId, data, cancellationToken);
+    }
+
     public Task Delete(string table, CancellationToken cancellationToken = default)
     {
         return _engine.Delete(table, cancellationToken);
@@ -98,6 +108,11 @@ public class SurrealDbMemoryClient : ISurrealDbClient
     public Task<bool> Delete(Thing thing, CancellationToken cancellationToken = default)
     {
         return _engine.Delete(thing, cancellationToken);
+    }
+
+    public Task<bool> Delete(StringRecordId recordId, CancellationToken cancellationToken = default)
+    {
+        return _engine.Delete(recordId, cancellationToken);
     }
 
     public void Dispose()
@@ -182,6 +197,15 @@ public class SurrealDbMemoryClient : ISurrealDbClient
         return _engine.Merge<T>(thing, data, cancellationToken);
     }
 
+    public Task<T> Merge<T>(
+        StringRecordId recordId,
+        Dictionary<string, object> data,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return _engine.Merge<T>(recordId, data, cancellationToken);
+    }
+
     public Task<IEnumerable<TOutput>> MergeAll<TMerge, TOutput>(
         string table,
         TMerge data,
@@ -209,6 +233,16 @@ public class SurrealDbMemoryClient : ISurrealDbClient
         where T : class
     {
         return _engine.Patch(thing, patches, cancellationToken);
+    }
+
+    public Task<T> Patch<T>(
+        StringRecordId recordId,
+        JsonPatchDocument<T> patches,
+        CancellationToken cancellationToken = default
+    )
+        where T : class
+    {
+        return _engine.Patch(recordId, patches, cancellationToken);
     }
 
     public Task<IEnumerable<T>> PatchAll<T>(
@@ -378,6 +412,14 @@ public class SurrealDbMemoryClient : ISurrealDbClient
         return _engine.Select<T?>(thing, cancellationToken);
     }
 
+    public Task<T?> Select<T>(
+        StringRecordId recordId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return _engine.Select<T?>(recordId, cancellationToken);
+    }
+
     public Task Set(string key, object value, CancellationToken cancellationToken = default)
     {
         return _engine.Set(key, value, cancellationToken);
@@ -429,6 +471,16 @@ public class SurrealDbMemoryClient : ISurrealDbClient
         where T : Record
     {
         return _engine.Upsert(data, cancellationToken);
+    }
+
+    public Task<TOutput> Upsert<TData, TOutput>(
+        StringRecordId recordId,
+        TData data,
+        CancellationToken cancellationToken = default
+    )
+        where TOutput : Record
+    {
+        return _engine.Upsert<TData, TOutput>(recordId, data, cancellationToken);
     }
 
     public Task Use(string ns, string db, CancellationToken cancellationToken = default)

--- a/SurrealDb.Net.Tests/CreateTests.cs
+++ b/SurrealDb.Net.Tests/CreateTests.cs
@@ -214,10 +214,17 @@ public class CreateTests
     }
 
     [Theory]
-    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=JSON", Skip = "To be removed")]
-    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=CBOR")]
-    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=JSON", Skip = "To be removed")]
-    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=CBOR")]
+    [InlineData("Endpoint=mem://")]
+    [InlineData(
+        "Endpoint=http://127.0.0.1:8000;User=root;Pass=root;Serialization=JSON",
+        Skip = "To be removed"
+    )]
+    [InlineData("Endpoint=http://127.0.0.1:8000;User=root;Pass=root;Serialization=CBOR")]
+    [InlineData(
+        "Endpoint=ws://127.0.0.1:8000/rpc;User=root;Pass=root;Serialization=JSON",
+        Skip = "To be removed"
+    )]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;User=root;Pass=root;Serialization=CBOR")]
     public async Task ShouldCreatePostUsingStringRecordId(string connectionString)
     {
         IEnumerable<Post>? list = null;
@@ -237,7 +244,6 @@ public class CreateTests
             string query = fileContent;
 
             using var client = surrealDbClientGenerator.Create(connectionString);
-            await client.SignIn(new RootAuth { Username = "root", Password = "root" });
             await client.Use(dbInfo.Namespace, dbInfo.Database);
             await client.RawQuery(query);
 

--- a/SurrealDb.Net.Tests/CreateTests.cs
+++ b/SurrealDb.Net.Tests/CreateTests.cs
@@ -212,4 +212,54 @@ public class CreateTests
 
         list.Should().NotBeNull().And.HaveCount(5);
     }
+
+    [Theory]
+    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=JSON", Skip = "To be removed")]
+    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=CBOR")]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=JSON", Skip = "To be removed")]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=CBOR")]
+    public async Task ShouldCreatePostUsingStringRecordId(string connectionString)
+    {
+        IEnumerable<Post>? list = null;
+        Post? result = null;
+
+        Func<Task> func = async () =>
+        {
+            await using var surrealDbClientGenerator = new SurrealDbClientGenerator();
+            var dbInfo = surrealDbClientGenerator.GenerateDatabaseInfo();
+
+            string filePath = Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory,
+                "Schemas/post.surql"
+            );
+            string fileContent = File.ReadAllText(filePath, Encoding.UTF8);
+
+            string query = fileContent;
+
+            using var client = surrealDbClientGenerator.Create(connectionString);
+            await client.SignIn(new RootAuth { Username = "root", Password = "root" });
+            await client.Use(dbInfo.Namespace, dbInfo.Database);
+            await client.RawQuery(query);
+
+            var post = new Post
+            {
+                Title = "A new article",
+                Content = "This is a new article created using the .NET SDK"
+            };
+
+            result = await client.Create<Post, Post>(new StringRecordId("post:new"), post, default);
+
+            list = await client.Select<Post>("post");
+        };
+
+        await func.Should().NotThrowAsync();
+
+        list.Should().NotBeNull().And.HaveCount(3);
+
+        result.Should().NotBeNull();
+        result!.Title.Should().Be("A new article");
+        result!.Content.Should().Be("This is a new article created using the .NET SDK");
+        result!.CreatedAt.Should().NotBeNull();
+        result!.Status.Should().Be("DRAFT");
+    }
 }

--- a/SurrealDb.Net.Tests/DeleteTests.cs
+++ b/SurrealDb.Net.Tests/DeleteTests.cs
@@ -169,10 +169,17 @@ public class DeleteTests
     }
 
     [Theory]
-    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=JSON", Skip = "To be removed")]
-    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=CBOR")]
-    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=JSON", Skip = "To be removed")]
-    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=CBOR")]
+    [InlineData("Endpoint=mem://")]
+    [InlineData(
+        "Endpoint=http://127.0.0.1:8000;User=root;Pass=root;Serialization=JSON",
+        Skip = "To be removed"
+    )]
+    [InlineData("Endpoint=http://127.0.0.1:8000;User=root;Pass=root;Serialization=CBOR")]
+    [InlineData(
+        "Endpoint=ws://127.0.0.1:8000/rpc;User=root;Pass=root;Serialization=JSON",
+        Skip = "To be removed"
+    )]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;User=root;Pass=root;Serialization=CBOR")]
     public async Task ShouldDeletePostRecordUsingStringRecordId(string connectionString)
     {
         IEnumerable<Post>? list = null;
@@ -192,7 +199,6 @@ public class DeleteTests
             string query = fileContent;
 
             using var client = surrealDbClientGenerator.Create(connectionString);
-            await client.SignIn(new RootAuth { Username = "root", Password = "root" });
             await client.Use(dbInfo.Namespace, dbInfo.Database);
             await client.RawQuery(query);
 

--- a/SurrealDb.Net.Tests/DeleteTests.cs
+++ b/SurrealDb.Net.Tests/DeleteTests.cs
@@ -113,9 +113,7 @@ public class DeleteTests
             await client.Use(dbInfo.Namespace, dbInfo.Database);
             await client.RawQuery(query);
 
-            var thing = new Thing("post", "first");
-
-            result = await client.Delete(thing);
+            result = await client.Delete(("post", "first"));
 
             list = await client.Select<Post>("post");
         };
@@ -159,9 +157,7 @@ public class DeleteTests
             await client.Use(dbInfo.Namespace, dbInfo.Database);
             await client.RawQuery(query);
 
-            var thing = new Thing("post", "inexistent");
-
-            result = await client.Delete(thing);
+            result = await client.Delete(("post", "inexistent"));
 
             list = await client.Select<Post>("post");
         };
@@ -170,5 +166,49 @@ public class DeleteTests
 
         list.Should().NotBeNull().And.HaveCount(2);
         result.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=JSON", Skip = "To be removed")]
+    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=CBOR")]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=JSON", Skip = "To be removed")]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=CBOR")]
+    public async Task ShouldDeletePostRecordUsingStringRecordId(string connectionString)
+    {
+        IEnumerable<Post>? list = null;
+        bool? result = null;
+
+        Func<Task> func = async () =>
+        {
+            await using var surrealDbClientGenerator = new SurrealDbClientGenerator();
+            var dbInfo = surrealDbClientGenerator.GenerateDatabaseInfo();
+
+            string filePath = Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory,
+                "Schemas/post.surql"
+            );
+            string fileContent = File.ReadAllText(filePath, Encoding.UTF8);
+
+            string query = fileContent;
+
+            using var client = surrealDbClientGenerator.Create(connectionString);
+            await client.SignIn(new RootAuth { Username = "root", Password = "root" });
+            await client.Use(dbInfo.Namespace, dbInfo.Database);
+            await client.RawQuery(query);
+
+            result = await client.Delete(new StringRecordId("post:first"));
+
+            list = await client.Select<Post>("post");
+        };
+
+        await func.Should().NotThrowAsync();
+
+        list.Should().NotBeNull().And.HaveCount(1);
+
+        var firstPost = list!.FirstOrDefault(p => p.Id!.Id == "first");
+
+        firstPost.Should().BeNull();
+
+        result.Should().BeTrue();
     }
 }

--- a/SurrealDb.Net.Tests/MergeTests.cs
+++ b/SurrealDb.Net.Tests/MergeTests.cs
@@ -114,10 +114,17 @@ public class MergeTests
     }
 
     [Theory]
-    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=JSON", Skip = "To be removed")]
-    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=CBOR")]
-    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=JSON", Skip = "To be removed")]
-    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=CBOR")]
+    [InlineData("Endpoint=mem://")]
+    [InlineData(
+        "Endpoint=http://127.0.0.1:8000;User=root;Pass=root;Serialization=JSON",
+        Skip = "To be removed"
+    )]
+    [InlineData("Endpoint=http://127.0.0.1:8000;User=root;Pass=root;Serialization=CBOR")]
+    [InlineData(
+        "Endpoint=ws://127.0.0.1:8000/rpc;User=root;Pass=root;Serialization=JSON",
+        Skip = "To be removed"
+    )]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;User=root;Pass=root;Serialization=CBOR")]
     public async Task ShouldMergeFromDictionaryUsingStringRecordId(string connectionString)
     {
         IEnumerable<Post>? list = null;
@@ -137,7 +144,6 @@ public class MergeTests
             string query = fileContent;
 
             using var client = surrealDbClientGenerator.Create(connectionString);
-            await client.SignIn(new RootAuth { Username = "root", Password = "root" });
             await client.Use(dbInfo.Namespace, dbInfo.Database);
             await client.RawQuery(query);
 

--- a/SurrealDb.Net.Tests/Models/StringRecordId/ConstructorsStringRecordIdTests.cs
+++ b/SurrealDb.Net.Tests/Models/StringRecordId/ConstructorsStringRecordIdTests.cs
@@ -1,0 +1,20 @@
+﻿namespace SurrealDb.Net.Tests.Models;
+
+public class ConstructorsStringRecordIdTests
+{
+    [Fact]
+    public void ThrowExceptionIfNoValueProvided()
+    {
+        var act = () => new StringRecordId();
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("A value is required");
+    }
+
+    [Fact]
+    public void ShouldCreateStringRecordId()
+    {
+        var recordId = new StringRecordId("table:id");
+
+        recordId.Value.Should().Be("table:id");
+    }
+}

--- a/SurrealDb.Net.Tests/Models/StringRecordId/ExplicitStringRecordIdTests.cs
+++ b/SurrealDb.Net.Tests/Models/StringRecordId/ExplicitStringRecordIdTests.cs
@@ -1,0 +1,12 @@
+﻿namespace SurrealDb.Net.Tests.Models;
+
+public class ExplicitStringRecordIdTests
+{
+    [Fact]
+    public void ShouldCreateStringRecordIdFromStringExplicitly()
+    {
+        var recordId = (StringRecordId)"table:id";
+
+        recordId.Value.Should().Be("table:id");
+    }
+}

--- a/SurrealDb.Net.Tests/Models/StringRecordId/OperatorsStringRecordIdTests.cs
+++ b/SurrealDb.Net.Tests/Models/StringRecordId/OperatorsStringRecordIdTests.cs
@@ -1,0 +1,20 @@
+﻿namespace SurrealDb.Net.Tests.Models;
+
+public class OperatorsStringRecordIdTests
+{
+    public static TheoryData<StringRecordId, StringRecordId, bool> EqualityCases =>
+        new()
+        {
+            { new StringRecordId("table:id"), new StringRecordId("table:id"), true },
+            { new StringRecordId("table:one"), new StringRecordId("table:two"), false },
+        };
+
+    [Theory]
+    [MemberData(nameof(EqualityCases))]
+    public void ShouldBe(StringRecordId recordId1, StringRecordId recordId2, bool expected)
+    {
+        bool result = recordId1 == recordId2;
+
+        result.Should().Be(expected);
+    }
+}

--- a/SurrealDb.Net.Tests/PatchTests.cs
+++ b/SurrealDb.Net.Tests/PatchTests.cs
@@ -60,10 +60,17 @@ public class PatchTests
     }
 
     [Theory]
-    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=JSON", Skip = "To be removed")]
-    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=CBOR")]
-    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=JSON", Skip = "To be removed")]
-    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=CBOR")]
+    [InlineData("Endpoint=mem://")]
+    [InlineData(
+        "Endpoint=http://127.0.0.1:8000;User=root;Pass=root;Serialization=JSON",
+        Skip = "To be removed"
+    )]
+    [InlineData("Endpoint=http://127.0.0.1:8000;User=root;Pass=root;Serialization=CBOR")]
+    [InlineData(
+        "Endpoint=ws://127.0.0.1:8000/rpc;User=root;Pass=root;Serialization=JSON",
+        Skip = "To be removed"
+    )]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;User=root;Pass=root;Serialization=CBOR")]
     public async Task ShouldPatchExistingPostUsingStringRecordId(string connectionString)
     {
         IEnumerable<Post>? list = null;
@@ -83,7 +90,6 @@ public class PatchTests
             string query = fileContent;
 
             using var client = surrealDbClientGenerator.Create(connectionString);
-            await client.SignIn(new RootAuth { Username = "root", Password = "root" });
             await client.Use(dbInfo.Namespace, dbInfo.Database);
             await client.RawQuery(query);
 

--- a/SurrealDb.Net.Tests/PatchTests.cs
+++ b/SurrealDb.Net.Tests/PatchTests.cs
@@ -43,9 +43,59 @@ public class PatchTests
             };
             jsonPatchDocument.Replace(x => x.Content, "[Edit] This is my first article");
 
-            var thing = new Thing("post", "first");
+            result = await client.Patch(("post", "first"), jsonPatchDocument);
 
-            result = await client.Patch(thing, jsonPatchDocument);
+            list = await client.Select<Post>("post");
+        };
+
+        await func.Should().NotThrowAsync();
+
+        list.Should().NotBeNull().And.HaveCount(2);
+
+        result.Should().NotBeNull();
+        result!.Title.Should().Be("First article");
+        result!.Content.Should().Be("[Edit] This is my first article");
+        result!.CreatedAt.Should().NotBeNull();
+        result!.Status.Should().Be("DRAFT");
+    }
+
+    [Theory]
+    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=JSON", Skip = "To be removed")]
+    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=CBOR")]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=JSON", Skip = "To be removed")]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=CBOR")]
+    public async Task ShouldPatchExistingPostUsingStringRecordId(string connectionString)
+    {
+        IEnumerable<Post>? list = null;
+        Post? result = null;
+
+        Func<Task> func = async () =>
+        {
+            await using var surrealDbClientGenerator = new SurrealDbClientGenerator();
+            var dbInfo = surrealDbClientGenerator.GenerateDatabaseInfo();
+
+            string filePath = Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory,
+                "Schemas/post.surql"
+            );
+            string fileContent = File.ReadAllText(filePath, Encoding.UTF8);
+
+            string query = fileContent;
+
+            using var client = surrealDbClientGenerator.Create(connectionString);
+            await client.SignIn(new RootAuth { Username = "root", Password = "root" });
+            await client.Use(dbInfo.Namespace, dbInfo.Database);
+            await client.RawQuery(query);
+
+            var jsonPatchDocument = new JsonPatchDocument<Post>
+            {
+                Options = SurrealDbSerializerOptions.GetDefaultSerializerFromPolicy(
+                    JsonNamingPolicy.SnakeCaseLower
+                )
+            };
+            jsonPatchDocument.Replace(x => x.Content, "[Edit] This is my first article");
+
+            result = await client.Patch(new StringRecordId("post:first"), jsonPatchDocument);
 
             list = await client.Select<Post>("post");
         };

--- a/SurrealDb.Net.Tests/SelectTests.cs
+++ b/SurrealDb.Net.Tests/SelectTests.cs
@@ -383,10 +383,17 @@ public class SelectTests
     }
 
     [Theory]
-    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=JSON", Skip = "To be removed")]
-    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=CBOR")]
-    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=JSON", Skip = "To be removed")]
-    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=CBOR")]
+    [InlineData("Endpoint=mem://")]
+    [InlineData(
+        "Endpoint=http://127.0.0.1:8000;User=root;Pass=root;Serialization=JSON",
+        Skip = "To be removed"
+    )]
+    [InlineData("Endpoint=http://127.0.0.1:8000;User=root;Pass=root;Serialization=CBOR")]
+    [InlineData(
+        "Endpoint=ws://127.0.0.1:8000/rpc;User=root;Pass=root;Serialization=JSON",
+        Skip = "To be removed"
+    )]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;User=root;Pass=root;Serialization=CBOR")]
     public async Task ShouldSelectSingleFromStringRecordIdType(string connectionString)
     {
         RecordIdRecord? result = null;
@@ -405,7 +412,6 @@ public class SelectTests
             string query = fileContent;
 
             using var client = surrealDbClientGenerator.Create(connectionString);
-            await client.SignIn(new RootAuth { Username = "root", Password = "root" });
             await client.Use(dbInfo.Namespace, dbInfo.Database);
             await client.RawQuery(query);
 

--- a/SurrealDb.Net.Tests/Serializers/Cbor/StringRecordIdConverterTests.cs
+++ b/SurrealDb.Net.Tests/Serializers/Cbor/StringRecordIdConverterTests.cs
@@ -1,0 +1,23 @@
+﻿namespace SurrealDb.Net.Tests.Serializers.Cbor;
+
+public class StringRecordIdConverterTests : BaseCborConverterTests
+{
+    [Fact]
+    public async Task Serialize()
+    {
+        string result = await SerializeCborBinaryAsHexaAsync(new StringRecordId("table:id"));
+
+        result.Should().Be("c8687461626c653a6964");
+    }
+
+    [Fact]
+    public async Task DeserializeShouldThrowException()
+    {
+        var act = async () =>
+            await DeserializeCborBinaryAsHexaAsync<StringRecordId>("c8687461626c653a6964");
+
+        await act.Should()
+            .ThrowAsync<NotSupportedException>()
+            .WithMessage("Cannot read StringRecordId from cbor...");
+    }
+}

--- a/SurrealDb.Net.Tests/UpsertTests.cs
+++ b/SurrealDb.Net.Tests/UpsertTests.cs
@@ -34,7 +34,7 @@ public class UpsertTests
 
             var post = new Post
             {
-                Id = new Thing("post", "another"),
+                Id = ("post", "another"),
                 Title = "A new article",
                 Content = "This is a new article created using the .NET SDK"
             };
@@ -96,7 +96,7 @@ public class UpsertTests
 
             var post = new Post
             {
-                Id = new Thing("post", "first"),
+                Id = ("post", "first"),
                 Title = "[Updated] First article",
                 Content = "[Edit] This is my first article",
                 CreatedAt = existingCreatedAt,
@@ -104,6 +104,119 @@ public class UpsertTests
             };
 
             result = await client.Upsert(post);
+
+            list = await client.Select<Post>("post");
+        };
+
+        await func.Should().NotThrowAsync();
+
+        list.Should().NotBeNull().And.HaveCount(2);
+
+        result.Should().NotBeNull();
+        result!.Title.Should().Be("[Updated] First article");
+        result!.Content.Should().Be("[Edit] This is my first article");
+        result!.CreatedAt.Should().NotBeNull();
+        result!.Status.Should().Be("DRAFT");
+    }
+
+    [Theory]
+    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=JSON", Skip = "To be removed")]
+    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=CBOR")]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=JSON", Skip = "To be removed")]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=CBOR")]
+    public async Task ShouldCreateNewPostUsingStringRecordId(string connectionString)
+    {
+        IEnumerable<Post>? list = null;
+        Post? result = null;
+
+        Func<Task> func = async () =>
+        {
+            await using var surrealDbClientGenerator = new SurrealDbClientGenerator();
+            var dbInfo = surrealDbClientGenerator.GenerateDatabaseInfo();
+
+            string filePath = Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory,
+                "Schemas/post.surql"
+            );
+            string fileContent = File.ReadAllText(filePath, Encoding.UTF8);
+
+            string query = fileContent;
+
+            using var client = surrealDbClientGenerator.Create(connectionString);
+            await client.SignIn(new RootAuth { Username = "root", Password = "root" });
+            await client.Use(dbInfo.Namespace, dbInfo.Database);
+            await client.RawQuery(query);
+
+            var post = new Post
+            {
+                Title = "A new article",
+                Content = "This is a new article created using the .NET SDK"
+            };
+
+            result = await client.Upsert<Post, Post>(new StringRecordId("post:another"), post);
+
+            list = await client.Select<Post>("post");
+        };
+
+        await func.Should().NotThrowAsync();
+
+        list.Should().NotBeNull().And.HaveCount(3);
+
+        result.Should().NotBeNull();
+        result!.Title.Should().Be("A new article");
+        result!.Content.Should().Be("This is a new article created using the .NET SDK");
+        result!.CreatedAt.Should().NotBeNull();
+        result!.Status.Should().Be("DRAFT");
+
+        var anotherPost = list!.First(r => r.Id!.Id == "another");
+
+        anotherPost.Should().NotBeNull();
+        anotherPost!.Title.Should().Be("A new article");
+        anotherPost!.Content.Should().Be("This is a new article created using the .NET SDK");
+        anotherPost!.CreatedAt.Should().NotBeNull();
+        anotherPost!.Status.Should().Be("DRAFT");
+    }
+
+    [Theory]
+    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=JSON", Skip = "To be removed")]
+    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=CBOR")]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=JSON", Skip = "To be removed")]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=CBOR")]
+    public async Task ShouldUpdateExistingPostUsingStringRecordId(string connectionString)
+    {
+        IEnumerable<Post>? list = null;
+        Post? result = null;
+
+        Func<Task> func = async () =>
+        {
+            await using var surrealDbClientGenerator = new SurrealDbClientGenerator();
+            var dbInfo = surrealDbClientGenerator.GenerateDatabaseInfo();
+
+            string filePath = Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory,
+                "Schemas/post.surql"
+            );
+            string fileContent = File.ReadAllText(filePath, Encoding.UTF8);
+
+            string query = fileContent;
+
+            using var client = surrealDbClientGenerator.Create(connectionString);
+            await client.SignIn(new RootAuth { Username = "root", Password = "root" });
+            await client.Use(dbInfo.Namespace, dbInfo.Database);
+            await client.RawQuery(query);
+
+            var existingCreatedAt = DateTime.UtcNow;
+            string existingStatus = "DRAFT";
+
+            var post = new Post
+            {
+                Title = "[Updated] First article",
+                Content = "[Edit] This is my first article",
+                CreatedAt = existingCreatedAt,
+                Status = existingStatus
+            };
+
+            result = await client.Upsert<Post, Post>(new StringRecordId("post:first"), post);
 
             list = await client.Select<Post>("post");
         };

--- a/SurrealDb.Net.Tests/UpsertTests.cs
+++ b/SurrealDb.Net.Tests/UpsertTests.cs
@@ -120,10 +120,17 @@ public class UpsertTests
     }
 
     [Theory]
-    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=JSON", Skip = "To be removed")]
-    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=CBOR")]
-    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=JSON", Skip = "To be removed")]
-    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=CBOR")]
+    [InlineData("Endpoint=mem://")]
+    [InlineData(
+        "Endpoint=http://127.0.0.1:8000;User=root;Pass=root;Serialization=JSON",
+        Skip = "To be removed"
+    )]
+    [InlineData("Endpoint=http://127.0.0.1:8000;User=root;Pass=root;Serialization=CBOR")]
+    [InlineData(
+        "Endpoint=ws://127.0.0.1:8000/rpc;User=root;Pass=root;Serialization=JSON",
+        Skip = "To be removed"
+    )]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;User=root;Pass=root;Serialization=CBOR")]
     public async Task ShouldCreateNewPostUsingStringRecordId(string connectionString)
     {
         IEnumerable<Post>? list = null;
@@ -143,7 +150,6 @@ public class UpsertTests
             string query = fileContent;
 
             using var client = surrealDbClientGenerator.Create(connectionString);
-            await client.SignIn(new RootAuth { Username = "root", Password = "root" });
             await client.Use(dbInfo.Namespace, dbInfo.Database);
             await client.RawQuery(query);
 
@@ -178,10 +184,17 @@ public class UpsertTests
     }
 
     [Theory]
-    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=JSON", Skip = "To be removed")]
-    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=CBOR")]
-    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=JSON", Skip = "To be removed")]
-    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=CBOR")]
+    [InlineData("Endpoint=mem://")]
+    [InlineData(
+        "Endpoint=http://127.0.0.1:8000;User=root;Pass=root;Serialization=JSON",
+        Skip = "To be removed"
+    )]
+    [InlineData("Endpoint=http://127.0.0.1:8000;User=root;Pass=root;Serialization=CBOR")]
+    [InlineData(
+        "Endpoint=ws://127.0.0.1:8000/rpc;User=root;Pass=root;Serialization=JSON",
+        Skip = "To be removed"
+    )]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;User=root;Pass=root;Serialization=CBOR")]
     public async Task ShouldUpdateExistingPostUsingStringRecordId(string connectionString)
     {
         IEnumerable<Post>? list = null;
@@ -201,7 +214,6 @@ public class UpsertTests
             string query = fileContent;
 
             using var client = surrealDbClientGenerator.Create(connectionString);
-            await client.SignIn(new RootAuth { Username = "root", Password = "root" });
             await client.Use(dbInfo.Namespace, dbInfo.Database);
             await client.RawQuery(query);
 

--- a/SurrealDb.Net/Internals/Cbor/Converters/PrimitiveConverterProvider.cs
+++ b/SurrealDb.Net/Internals/Cbor/Converters/PrimitiveConverterProvider.cs
@@ -37,6 +37,10 @@ internal class PrimitiveConverterProvider : CborConverterProviderBase
         {
             return new NoneConverter();
         }
+        if (type == typeof(StringRecordId))
+        {
+            return new StringRecordIdConverter();
+        }
 
 #if NET6_0_OR_GREATER
         if (type == typeof(DateOnly))

--- a/SurrealDb.Net/Internals/Cbor/Converters/StringRecordIdConverter.cs
+++ b/SurrealDb.Net/Internals/Cbor/Converters/StringRecordIdConverter.cs
@@ -1,0 +1,19 @@
+﻿using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Serialization.Converters;
+using SurrealDb.Net.Models;
+
+namespace SurrealDb.Net.Internals.Cbor.Converters;
+
+internal class StringRecordIdConverter : CborConverterBase<StringRecordId>
+{
+    public override StringRecordId Read(ref CborReader reader)
+    {
+        throw new NotSupportedException($"Cannot read {nameof(StringRecordId)} from cbor...");
+    }
+
+    public override void Write(ref CborWriter writer, StringRecordId value)
+    {
+        writer.WriteSemanticTag(CborTagConstants.TAG_RECORDID);
+        writer.WriteString(value.Value);
+    }
+}

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Http.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Http.cs
@@ -450,6 +450,22 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
         return dbResponse.GetValue<T?>();
     }
 
+    public async Task<T?> Select<T>(StringRecordId recordId, CancellationToken cancellationToken)
+    {
+        if (!_useCbor)
+        {
+            throw new NotImplementedException(
+                $"Selecting by {nameof(StringRecordId)} is only available via CBOR serialization."
+            );
+        }
+
+        var request = new SurrealDbHttpRequest { Method = "select", Parameters = [recordId] };
+
+        var dbResponse = await ExecuteRequestAsync(request, cancellationToken)
+            .ConfigureAwait(false);
+        return dbResponse.GetValue<T?>();
+    }
+
     public async Task Set(string key, object value, CancellationToken cancellationToken)
     {
         if (key is null)

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Interface.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Interface.cs
@@ -93,6 +93,7 @@ public interface ISurrealDbEngine : IDisposable
         where TOutput : class;
     Task<IEnumerable<T>> Select<T>(string table, CancellationToken cancellationToken);
     Task<T?> Select<T>(Thing thing, CancellationToken cancellationToken);
+    Task<T?> Select<T>(StringRecordId recordId, CancellationToken cancellationToken);
     Task Set(string key, object value, CancellationToken cancellationToken);
     Task SignIn(RootAuth root, CancellationToken cancellationToken);
     Task<Jwt> SignIn(NamespaceAuth nsAuth, CancellationToken cancellationToken);

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Interface.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Interface.cs
@@ -18,8 +18,15 @@ public interface ISurrealDbEngine : IDisposable
     Task<T> Create<T>(T data, CancellationToken cancellationToken)
         where T : Record;
     Task<T> Create<T>(string table, T? data, CancellationToken cancellationToken);
+    Task<TOutput> Create<TData, TOutput>(
+        StringRecordId recordId,
+        TData? data,
+        CancellationToken cancellationToken
+    )
+        where TOutput : Record;
     Task Delete(string table, CancellationToken cancellationToken);
     Task<bool> Delete(Thing thing, CancellationToken cancellationToken);
+    Task<bool> Delete(StringRecordId recordId, CancellationToken cancellationToken);
     Task<bool> Health(CancellationToken cancellationToken);
     Task<T> Info<T>(CancellationToken cancellationToken);
     Task Invalidate(CancellationToken cancellationToken);
@@ -50,6 +57,11 @@ public interface ISurrealDbEngine : IDisposable
         Dictionary<string, object> data,
         CancellationToken cancellationToken
     );
+    Task<T> Merge<T>(
+        StringRecordId recordId,
+        Dictionary<string, object> data,
+        CancellationToken cancellationToken
+    );
     Task<IEnumerable<TOutput>> MergeAll<TMerge, TOutput>(
         string table,
         TMerge data,
@@ -62,6 +74,12 @@ public interface ISurrealDbEngine : IDisposable
         CancellationToken cancellationToken
     );
     Task<T> Patch<T>(Thing thing, JsonPatchDocument<T> patches, CancellationToken cancellationToken)
+        where T : class;
+    Task<T> Patch<T>(
+        StringRecordId recordId,
+        JsonPatchDocument<T> patches,
+        CancellationToken cancellationToken
+    )
         where T : class;
     Task<IEnumerable<T>> PatchAll<T>(
         string table,
@@ -108,6 +126,12 @@ public interface ISurrealDbEngine : IDisposable
         where T : class;
     Task<T> Upsert<T>(T data, CancellationToken cancellationToken)
         where T : Record;
+    Task<TOutput> Upsert<TData, TOutput>(
+        StringRecordId recordId,
+        TData data,
+        CancellationToken cancellationToken
+    )
+        where TOutput : Record;
     Task Use(string ns, string db, CancellationToken cancellationToken);
     Task<string> Version(CancellationToken cancellationToken);
 }

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
@@ -365,6 +365,25 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         return dbResponse.DeserializeEnumerable<T>().First();
     }
 
+    public async Task<TOutput> Create<TData, TOutput>(
+        StringRecordId recordId,
+        TData? data,
+        CancellationToken cancellationToken
+    )
+        where TOutput : Record
+    {
+        if (!_useCbor)
+        {
+            throw new NotImplementedException(
+                $"Creating by {nameof(StringRecordId)} is only available via CBOR serialization."
+            );
+        }
+
+        var dbResponse = await SendRequestAsync("create", [recordId, data], true, cancellationToken)
+            .ConfigureAwait(false);
+        return dbResponse.GetValue<TOutput>()!;
+    }
+
     public async Task Delete(string table, CancellationToken cancellationToken)
     {
         await SendRequestAsync("delete", [table], true, cancellationToken).ConfigureAwait(false);
@@ -375,6 +394,27 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         object?[] @params = _useCbor ? [thing] : [thing.ToString()];
 
         var dbResponse = await SendRequestAsync("delete", @params, true, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (dbResponse.Result.HasValue)
+        {
+            var valueKind = dbResponse.Result.Value.ValueKind;
+            return valueKind != JsonValueKind.Null && valueKind != JsonValueKind.Undefined;
+        }
+
+        return !dbResponse.ExpectNone() && !dbResponse.ExpectEmptyArray();
+    }
+
+    public async Task<bool> Delete(StringRecordId recordId, CancellationToken cancellationToken)
+    {
+        if (!_useCbor)
+        {
+            throw new NotImplementedException(
+                $"Deleting by {nameof(StringRecordId)} is only available via CBOR serialization."
+            );
+        }
+
+        var dbResponse = await SendRequestAsync("delete", [recordId], true, cancellationToken)
             .ConfigureAwait(false);
 
         if (dbResponse.Result.HasValue)
@@ -592,6 +632,24 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         return dbResponse.GetValue<T>()!;
     }
 
+    public async Task<T> Merge<T>(
+        StringRecordId recordId,
+        Dictionary<string, object> data,
+        CancellationToken cancellationToken
+    )
+    {
+        if (!_useCbor)
+        {
+            throw new NotImplementedException(
+                $"Merging by {nameof(StringRecordId)} is only available via CBOR serialization."
+            );
+        }
+
+        var dbResponse = await SendRequestAsync("merge", [recordId, data], true, cancellationToken)
+            .ConfigureAwait(false);
+        return dbResponse.GetValue<T>()!;
+    }
+
     public async Task<IEnumerable<TOutput>> MergeAll<TMerge, TOutput>(
         string table,
         TMerge data,
@@ -625,6 +683,30 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         object?[] @params = _useCbor ? [thing, patches] : [thing.ToWsString(), patches];
 
         var dbResponse = await SendRequestAsync("patch", @params, true, cancellationToken)
+            .ConfigureAwait(false);
+        return dbResponse.GetValue<T>()!;
+    }
+
+    public async Task<T> Patch<T>(
+        StringRecordId recordId,
+        JsonPatchDocument<T> patches,
+        CancellationToken cancellationToken
+    )
+        where T : class
+    {
+        if (!_useCbor)
+        {
+            throw new NotImplementedException(
+                $"Patching by {nameof(StringRecordId)} is only available via CBOR serialization."
+            );
+        }
+
+        var dbResponse = await SendRequestAsync(
+                "patch",
+                [recordId, patches],
+                true,
+                cancellationToken
+            )
             .ConfigureAwait(false);
         return dbResponse.GetValue<T>()!;
     }
@@ -851,6 +933,25 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         var dbResponse = await SendRequestAsync("update", @params, true, cancellationToken)
             .ConfigureAwait(false);
         return dbResponse.GetValue<T>()!;
+    }
+
+    public async Task<TOutput> Upsert<TData, TOutput>(
+        StringRecordId recordId,
+        TData data,
+        CancellationToken cancellationToken
+    )
+        where TOutput : Record
+    {
+        if (!_useCbor)
+        {
+            throw new NotImplementedException(
+                $"Upserting by {nameof(StringRecordId)} is only available via CBOR serialization."
+            );
+        }
+
+        var dbResponse = await SendRequestAsync("update", [recordId, data], true, cancellationToken)
+            .ConfigureAwait(false);
+        return dbResponse.GetValue<TOutput>()!;
     }
 
     public async Task Use(string ns, string db, CancellationToken cancellationToken)

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
@@ -724,6 +724,20 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         return dbResponse.GetValue<T?>();
     }
 
+    public async Task<T?> Select<T>(StringRecordId recordId, CancellationToken cancellationToken)
+    {
+        if (!_useCbor)
+        {
+            throw new NotImplementedException(
+                $"Selecting by {nameof(StringRecordId)} is only available via CBOR serialization."
+            );
+        }
+
+        var dbResponse = await SendRequestAsync("select", [recordId], true, cancellationToken)
+            .ConfigureAwait(false);
+        return dbResponse.GetValue<T?>();
+    }
+
     public async Task Set(string key, object value, CancellationToken cancellationToken)
     {
         if (key is null)

--- a/SurrealDb.Net/Models/StringRecordId.Operators.cs
+++ b/SurrealDb.Net/Models/StringRecordId.Operators.cs
@@ -1,0 +1,19 @@
+﻿namespace SurrealDb.Net.Models;
+
+public partial struct StringRecordId
+{
+    public static bool operator ==(StringRecordId left, StringRecordId right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(StringRecordId left, StringRecordId right)
+    {
+        return !(left == right);
+    }
+
+    public static explicit operator StringRecordId(string recordId)
+    {
+        return new(recordId);
+    }
+}

--- a/SurrealDb.Net/Models/StringRecordId.cs
+++ b/SurrealDb.Net/Models/StringRecordId.cs
@@ -1,0 +1,34 @@
+﻿namespace SurrealDb.Net.Models;
+
+/// <summary>
+/// A placeholder type that reflects a Record ID stored a single string.
+/// </summary>
+///
+/// <remarks>
+/// For performance reasons, the parsing of Record IDs is not implemented in the library,
+/// as that would require to parse any SurrealQL value in the provided <see cref="string"/>.
+/// And for this reason, this type is only used for one-way communication,
+/// sending a <see cref="StringRecordId"/> from the client to a SurrealDB instance.
+/// This library will never be able to deserialize a <see cref="StringRecordId"/> into a <see cref="Thing"/>.
+/// As such, please consider using <see cref="Thing"/> or one of its inherited types for these scenarii.
+/// </remarks>
+public readonly struct StringRecordId
+{
+    /// <summary>
+    /// The value representing the Record ID as a single string, e.g.
+    /// <example>"person:john"</example>
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Instanciate a new <see cref="StringRecordId"/> that will contain a Record ID representation as a single string.
+    /// </summary>
+    /// <param name="value">
+    /// The value representing the Record ID as a single string, e.g.
+    /// <example>"person:john"</example>
+    /// </param>
+    public StringRecordId(string value)
+    {
+        Value = value;
+    }
+}

--- a/SurrealDb.Net/Models/StringRecordId.cs
+++ b/SurrealDb.Net/Models/StringRecordId.cs
@@ -12,7 +12,9 @@
 /// This library will never be able to deserialize a <see cref="StringRecordId"/> into a <see cref="Thing"/>.
 /// As such, please consider using <see cref="Thing"/> or one of its inherited types for these scenarii.
 /// </remarks>
-public readonly partial struct StringRecordId : IEquatable<StringRecordId>
+public readonly partial struct StringRecordId
+    : IEquatable<StringRecordId>,
+        IComparable<StringRecordId>
 {
     /// <summary>
     /// The value representing the Record ID as a single string, e.g.
@@ -23,6 +25,7 @@ public readonly partial struct StringRecordId : IEquatable<StringRecordId>
     /// <summary>
     /// Instanciate a new <see cref="StringRecordId"/> that will contain a Record ID representation as a single string.
     /// </summary>
+    /// <exception cref="InvalidOperationException">A value is required</exception>
     public StringRecordId()
     {
         throw new InvalidOperationException("A value is required");
@@ -53,5 +56,10 @@ public readonly partial struct StringRecordId : IEquatable<StringRecordId>
     public bool Equals(StringRecordId other)
     {
         return Value == other.Value;
+    }
+
+    public int CompareTo(StringRecordId other)
+    {
+        return Value.CompareTo(other.Value);
     }
 }

--- a/SurrealDb.Net/Models/StringRecordId.cs
+++ b/SurrealDb.Net/Models/StringRecordId.cs
@@ -12,13 +12,21 @@
 /// This library will never be able to deserialize a <see cref="StringRecordId"/> into a <see cref="Thing"/>.
 /// As such, please consider using <see cref="Thing"/> or one of its inherited types for these scenarii.
 /// </remarks>
-public readonly struct StringRecordId
+public readonly partial struct StringRecordId : IEquatable<StringRecordId>
 {
     /// <summary>
     /// The value representing the Record ID as a single string, e.g.
     /// <example>"person:john"</example>
     /// </summary>
     public string Value { get; }
+
+    /// <summary>
+    /// Instanciate a new <see cref="StringRecordId"/> that will contain a Record ID representation as a single string.
+    /// </summary>
+    public StringRecordId()
+    {
+        throw new InvalidOperationException("A value is required");
+    }
 
     /// <summary>
     /// Instanciate a new <see cref="StringRecordId"/> that will contain a Record ID representation as a single string.
@@ -30,5 +38,20 @@ public readonly struct StringRecordId
     public StringRecordId(string value)
     {
         Value = value;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is StringRecordId recordId && Equals(recordId);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Value);
+    }
+
+    public bool Equals(StringRecordId other)
+    {
+        return Value == other.Value;
     }
 }

--- a/SurrealDb.Net/SurrealDbClient.Interface.cs
+++ b/SurrealDb.Net/SurrealDbClient.Interface.cs
@@ -576,6 +576,19 @@ public interface ISurrealDbClient : IDisposable
     Task<T?> Select<T>(Thing thing, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Selects a single record.
+    /// </summary>
+    /// <typeparam name="T">The type of the record</typeparam>
+    /// <param name="recordId">The record id.</param>
+    /// <param name="cancellationToken">The cancellationToken enables graceful cancellation of asynchronous operations</param>
+    /// <returns>The extracted record</returns>
+    /// <exception cref="OperationCanceledException"></exception>
+    /// <exception cref="HttpRequestException"></exception>
+    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="SurrealDbException"></exception>
+    Task<T?> Select<T>(StringRecordId recordId, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Assigns a value as a parameter for this connection.
     /// </summary>
     /// <param name="key">The name of the parameter.</param>

--- a/SurrealDb.Net/SurrealDbClient.Interface.cs
+++ b/SurrealDb.Net/SurrealDbClient.Interface.cs
@@ -97,6 +97,26 @@ public interface ISurrealDbClient : IDisposable
     );
 
     /// <summary>
+    /// Creates the specific record in the database.
+    /// </summary>
+    /// <typeparam name="TData">The type of data contained in the record.</typeparam>
+    /// <typeparam name="TOutput">The type of the record created.</typeparam>
+    /// <param name="recordId">The record id.</param>
+    /// <param name="data">The data contained in the record.</param>
+    /// <param name="cancellationToken">The cancellationToken enables graceful cancellation of asynchronous operations</param>
+    /// <returns>The record created.</returns>
+    /// <exception cref="OperationCanceledException"></exception>
+    /// <exception cref="HttpRequestException"></exception>
+    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="SurrealDbException"></exception>
+    Task<TOutput> Create<TData, TOutput>(
+        StringRecordId recordId,
+        TData? data = default,
+        CancellationToken cancellationToken = default
+    )
+        where TOutput : Record;
+
+    /// <summary>
     /// Deletes all records in a table from the database.
     /// </summary>
     /// <param name="table">The name of the database table</param>
@@ -118,6 +138,18 @@ public interface ISurrealDbClient : IDisposable
     /// <exception cref="InvalidOperationException"></exception>
     /// <exception cref="SurrealDbException"></exception>
     Task<bool> Delete(Thing thing, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes the specified record from the database.
+    /// </summary>
+    /// <param name="recordId">The record id.</param>
+    /// <param name="cancellationToken">The cancellationToken enables graceful cancellation of asynchronous operations</param>
+    /// <returns>Returns true if the record was removed successfully.</returns>
+    /// <exception cref="OperationCanceledException"></exception>
+    /// <exception cref="HttpRequestException"></exception>
+    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="SurrealDbException"></exception>
+    Task<bool> Delete(StringRecordId recordId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Checks the status of the database server and storage engine.
@@ -265,6 +297,24 @@ public interface ISurrealDbClient : IDisposable
     );
 
     /// <summary>
+    /// Modifies the specified record in the database.
+    /// </summary>
+    /// <typeparam name="T">The type of the record updated.</typeparam>
+    /// <param name="recordId">The record id.</param>
+    /// <param name="data">A list of key-value pairs that contains properties to change.</param>
+    /// <param name="cancellationToken">The cancellationToken enables graceful cancellation of asynchronous operations</param>
+    /// <returns>The record updated.</returns>
+    /// <exception cref="OperationCanceledException"></exception>
+    /// <exception cref="HttpRequestException"></exception>
+    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="SurrealDbException"></exception>
+    Task<T> Merge<T>(
+        StringRecordId recordId,
+        Dictionary<string, object> data,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
     /// Modifies all records in the database.
     /// </summary>
     /// <typeparam name="TMerge">The type of the merge update.</typeparam>
@@ -312,6 +362,21 @@ public interface ISurrealDbClient : IDisposable
     /// <returns>The record updated.</returns>
     Task<T> Patch<T>(
         Thing thing,
+        JsonPatchDocument<T> patches,
+        CancellationToken cancellationToken = default
+    )
+        where T : class;
+
+    /// <summary>
+    /// Modifies the specified record in the database, using JSON Patch specification (https://jsonpatch.com/).
+    /// </summary>
+    /// <typeparam name="T">The type of the record updated.</typeparam>
+    /// <param name="recordId">The record id.</param>
+    /// <param name="patches">A list of JSON Patch operations.</param>
+    /// <param name="cancellationToken">The cancellationToken enables graceful cancellation of asynchronous operations</param>
+    /// <returns>The record updated.</returns>
+    Task<T> Patch<T>(
+        StringRecordId recordId,
         JsonPatchDocument<T> patches,
         CancellationToken cancellationToken = default
     )
@@ -708,6 +773,26 @@ public interface ISurrealDbClient : IDisposable
     /// <exception cref="SurrealDbException"></exception>
     Task<T> Upsert<T>(T data, CancellationToken cancellationToken = default)
         where T : Record;
+
+    /// <summary>
+    /// Updates or creates the specified record in the database.
+    /// </summary>
+    /// <typeparam name="TData">The type of data contained in the record.</typeparam>
+    /// <typeparam name="TOutput">The type of the record created.</typeparam>
+    /// <param name="recordId">The record id.</param>
+    /// <param name="data">The record to create or update.</param>
+    /// <param name="cancellationToken">The cancellationToken enables graceful cancellation of asynchronous operations</param>
+    /// <returns>The record created or updated.</returns>
+    /// <exception cref="OperationCanceledException"></exception>
+    /// <exception cref="HttpRequestException"></exception>
+    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="SurrealDbException"></exception>
+    Task<TOutput> Upsert<TData, TOutput>(
+        StringRecordId recordId,
+        TData data,
+        CancellationToken cancellationToken = default
+    )
+        where TOutput : Record;
 
     /// <summary>
     /// Switch to a specific namespace and database.

--- a/SurrealDb.Net/SurrealDbClient.cs
+++ b/SurrealDb.Net/SurrealDbClient.cs
@@ -483,6 +483,14 @@ public class SurrealDbClient : ISurrealDbClient
         return _engine.Select<T?>(thing, cancellationToken);
     }
 
+    public Task<T?> Select<T>(
+        StringRecordId recordId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return _engine.Select<T?>(recordId, cancellationToken);
+    }
+
     public Task Set(string key, object value, CancellationToken cancellationToken = default)
     {
         return _engine.Set(key, value, cancellationToken);

--- a/SurrealDb.Net/SurrealDbClient.cs
+++ b/SurrealDb.Net/SurrealDbClient.cs
@@ -195,6 +195,16 @@ public class SurrealDbClient : ISurrealDbClient
         return _engine.Create(table, data, cancellationToken);
     }
 
+    public Task<TOutput> Create<TData, TOutput>(
+        StringRecordId recordId,
+        TData? data = default,
+        CancellationToken cancellationToken = default
+    )
+        where TOutput : Record
+    {
+        return _engine.Create<TData, TOutput>(recordId, data, cancellationToken);
+    }
+
     public Task Delete(string table, CancellationToken cancellationToken = default)
     {
         return _engine.Delete(table, cancellationToken);
@@ -203,6 +213,11 @@ public class SurrealDbClient : ISurrealDbClient
     public Task<bool> Delete(Thing thing, CancellationToken cancellationToken = default)
     {
         return _engine.Delete(thing, cancellationToken);
+    }
+
+    public Task<bool> Delete(StringRecordId recordId, CancellationToken cancellationToken = default)
+    {
+        return _engine.Delete(recordId, cancellationToken);
     }
 
     public void Dispose()
@@ -287,6 +302,15 @@ public class SurrealDbClient : ISurrealDbClient
         return _engine.Merge<T>(thing, data, cancellationToken);
     }
 
+    public Task<T> Merge<T>(
+        StringRecordId recordId,
+        Dictionary<string, object> data,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return _engine.Merge<T>(recordId, data, cancellationToken);
+    }
+
     public Task<IEnumerable<TOutput>> MergeAll<TMerge, TOutput>(
         string table,
         TMerge data,
@@ -314,6 +338,16 @@ public class SurrealDbClient : ISurrealDbClient
         where T : class
     {
         return _engine.Patch(thing, patches, cancellationToken);
+    }
+
+    public Task<T> Patch<T>(
+        StringRecordId recordId,
+        JsonPatchDocument<T> patches,
+        CancellationToken cancellationToken = default
+    )
+        where T : class
+    {
+        return _engine.Patch(recordId, patches, cancellationToken);
     }
 
     public Task<IEnumerable<T>> PatchAll<T>(
@@ -542,6 +576,16 @@ public class SurrealDbClient : ISurrealDbClient
         where T : Record
     {
         return _engine.Upsert(data, cancellationToken);
+    }
+
+    public Task<TOutput> Upsert<TData, TOutput>(
+        StringRecordId recordId,
+        TData data,
+        CancellationToken cancellationToken = default
+    )
+        where TOutput : Record
+    {
+        return _engine.Upsert<TData, TOutput>(recordId, data, cancellationToken);
     }
 
     public Task Use(string ns, string db, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What does this change do?

Adds a new `StringRecordId` type that can be used in `Select`, `Create` `Merge`, `Patch` and `Upsert` methods.
`StringRecordId` contains a string value of the full record id, without parsing it (as this is handled by the server).

## What is your testing strategy?

Unit & Integration tests

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)