### PR TITLE
⚡️ use an InterpolatedStringHandler for Query string

### DIFF
--- a/SurrealDb.Embedded.InMemory/SurrealDbMemoryClient.cs
+++ b/SurrealDb.Embedded.InMemory/SurrealDbMemoryClient.cs
@@ -173,11 +173,7 @@ public class SurrealDbMemoryClient : ISurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return _engine.LiveRawQuery<T>(
-            query.GetFormattedText(),
-            query.GetParameters(),
-            cancellationToken
-        );
+        return _engine.LiveRawQuery<T>(query.FormattedText, query.Parameters, cancellationToken);
     }
 #else
     public Task<SurrealDbLiveQuery<T>> LiveQuery<T>(
@@ -281,7 +277,7 @@ public class SurrealDbMemoryClient : ISurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return _engine.RawQuery(query.GetFormattedText(), query.GetParameters(), cancellationToken);
+        return _engine.RawQuery(query.FormattedText, query.Parameters, cancellationToken);
     }
 #else
     public Task<SurrealDbResponse> Query(

--- a/SurrealDb.Net.LocalBenchmarks/QueryFormatterBenchmark.cs
+++ b/SurrealDb.Net.LocalBenchmarks/QueryFormatterBenchmark.cs
@@ -128,6 +128,6 @@ public class QueryFormatterBenchmark
         QueryInterpolatedStringHandler handler
     )
     {
-        return (handler.GetFormattedText(), handler.GetParameters());
+        return (handler.FormattedText, handler.Parameters);
     }
 }

--- a/SurrealDb.Net.LocalBenchmarks/QueryFormatterBenchmark.cs
+++ b/SurrealDb.Net.LocalBenchmarks/QueryFormatterBenchmark.cs
@@ -38,6 +38,31 @@ public class QueryFormatterBenchmark
     }
 
     [Benchmark]
+    public List<(string, IReadOnlyDictionary<string, object?>)> FormattableStringNoInterpolation()
+    {
+        var list = new List<(string, IReadOnlyDictionary<string, object?>)>(Param);
+
+        for (int index = 0; index < Param; index++)
+        {
+            list.Add(
+                ExtractRawQueryParams(
+                    $"""
+                    DEFINE TABLE test;
+
+                    CREATE test SET value = 5;
+                    UPDATE test SET value = 10;
+                    DELETE test;
+
+                    SELECT * FROM test;
+                    """
+                )
+            );
+        }
+
+        return list;
+    }
+
+    [Benchmark]
     public List<(string, IReadOnlyDictionary<string, object?>)> QueryInterpolatedStringHandler()
     {
         var list = new List<(string, IReadOnlyDictionary<string, object?>)>(Param);
@@ -54,6 +79,34 @@ public class QueryFormatterBenchmark
                     DELETE {TABLE};
 
                     SELECT * FROM {TABLE};
+                    """
+                )
+            );
+        }
+
+        return list;
+    }
+
+    [Benchmark]
+    public List<(
+        string,
+        IReadOnlyDictionary<string, object?>
+    )> QueryInterpolatedStringHandlerNoInterpolation()
+    {
+        var list = new List<(string, IReadOnlyDictionary<string, object?>)>(Param);
+
+        for (int index = 0; index < Param; index++)
+        {
+            list.Add(
+                HandleQuery(
+                    $"""
+                    DEFINE TABLE test;
+
+                    CREATE test SET value = 5;
+                    UPDATE test SET value = 10;
+                    DELETE test;
+
+                    SELECT * FROM test;
                     """
                 )
             );

--- a/SurrealDb.Net.LocalBenchmarks/QueryFormatterBenchmark.cs
+++ b/SurrealDb.Net.LocalBenchmarks/QueryFormatterBenchmark.cs
@@ -1,0 +1,80 @@
+﻿using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using SurrealDb.Net.Handlers;
+using SurrealDb.Net.Internals.Extensions;
+
+namespace SurrealDb.Net.LocalBenchmarks;
+
+public class QueryFormatterBenchmark
+{
+    private const string TABLE = "test";
+
+    [Params(1, 100)]
+    public int Param;
+
+    [Benchmark]
+    public List<(string, IReadOnlyDictionary<string, object?>)> FormattableString()
+    {
+        var list = new List<(string, IReadOnlyDictionary<string, object?>)>(Param);
+
+        for (int index = 0; index < Param; index++)
+        {
+            list.Add(
+                ExtractRawQueryParams(
+                    $"""
+                    DEFINE TABLE {TABLE};
+
+                    CREATE {TABLE} SET value = {5};
+                    UPDATE {TABLE} SET value = {10};
+                    DELETE {TABLE};
+
+                    SELECT * FROM {TABLE};
+                    """
+                )
+            );
+        }
+
+        return list;
+    }
+
+    [Benchmark]
+    public List<(string, IReadOnlyDictionary<string, object?>)> QueryInterpolatedStringHandler()
+    {
+        var list = new List<(string, IReadOnlyDictionary<string, object?>)>(Param);
+
+        for (int index = 0; index < Param; index++)
+        {
+            list.Add(
+                HandleQuery(
+                    $"""
+                    DEFINE TABLE {TABLE};
+
+                    CREATE {TABLE} SET value = {5};
+                    UPDATE {TABLE} SET value = {10};
+                    DELETE {TABLE};
+
+                    SELECT * FROM {TABLE};
+                    """
+                )
+            );
+        }
+
+        return list;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private (string, IReadOnlyDictionary<string, object?>) ExtractRawQueryParams(
+        FormattableString formattableString
+    )
+    {
+        return formattableString.ExtractRawQueryParams();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private (string, IReadOnlyDictionary<string, object?>) HandleQuery(
+        QueryInterpolatedStringHandler handler
+    )
+    {
+        return (handler.GetFormattedText(), handler.GetParameters());
+    }
+}

--- a/SurrealDb.Net.LocalBenchmarks/QueryFormatterBenchmark.cs
+++ b/SurrealDb.Net.LocalBenchmarks/QueryFormatterBenchmark.cs
@@ -10,53 +10,50 @@ public class QueryFormatterBenchmark
     private const string TABLE = "test";
 
     [Params(1, 100)]
-    public int Param;
+    public int Count;
+
+    [Params("Interpolation", "NoInterpolation")]
+    public string Mode = string.Empty;
 
     [Benchmark]
     public List<(string, IReadOnlyDictionary<string, object?>)> FormattableString()
     {
-        var list = new List<(string, IReadOnlyDictionary<string, object?>)>(Param);
+        var list = new List<(string, IReadOnlyDictionary<string, object?>)>(Count);
 
-        for (int index = 0; index < Param; index++)
+        for (int index = 0; index < Count; index++)
         {
-            list.Add(
-                ExtractRawQueryParams(
-                    $"""
-                    DEFINE TABLE {TABLE};
+            if (Mode == "NoInterpolation")
+            {
+                list.Add(
+                    ExtractRawQueryParams(
+                        $"""
+                        DEFINE TABLE test;
 
-                    CREATE {TABLE} SET value = {5};
-                    UPDATE {TABLE} SET value = {10};
-                    DELETE {TABLE};
+                        CREATE test SET value = 5;
+                        UPDATE test SET value = 10;
+                        DELETE test;
 
-                    SELECT * FROM {TABLE};
-                    """
-                )
-            );
-        }
+                        SELECT * FROM test;
+                        """
+                    )
+                );
+            }
+            else
+            {
+                list.Add(
+                    ExtractRawQueryParams(
+                        $"""
+                        DEFINE TABLE {TABLE};
 
-        return list;
-    }
+                        CREATE {TABLE} SET value = {5};
+                        UPDATE {TABLE} SET value = {10};
+                        DELETE {TABLE};
 
-    [Benchmark]
-    public List<(string, IReadOnlyDictionary<string, object?>)> FormattableStringNoInterpolation()
-    {
-        var list = new List<(string, IReadOnlyDictionary<string, object?>)>(Param);
-
-        for (int index = 0; index < Param; index++)
-        {
-            list.Add(
-                ExtractRawQueryParams(
-                    $"""
-                    DEFINE TABLE test;
-
-                    CREATE test SET value = 5;
-                    UPDATE test SET value = 10;
-                    DELETE test;
-
-                    SELECT * FROM test;
-                    """
-                )
-            );
+                        SELECT * FROM {TABLE};
+                        """
+                    )
+                );
+            }
         }
 
         return list;
@@ -65,51 +62,42 @@ public class QueryFormatterBenchmark
     [Benchmark]
     public List<(string, IReadOnlyDictionary<string, object?>)> QueryInterpolatedStringHandler()
     {
-        var list = new List<(string, IReadOnlyDictionary<string, object?>)>(Param);
+        var list = new List<(string, IReadOnlyDictionary<string, object?>)>(Count);
 
-        for (int index = 0; index < Param; index++)
+        for (int index = 0; index < Count; index++)
         {
-            list.Add(
-                HandleQuery(
-                    $"""
-                    DEFINE TABLE {TABLE};
+            if (Mode == "NoInterpolation")
+            {
+                list.Add(
+                    HandleQuery(
+                        $"""
+                        DEFINE TABLE test;
 
-                    CREATE {TABLE} SET value = {5};
-                    UPDATE {TABLE} SET value = {10};
-                    DELETE {TABLE};
+                        CREATE test SET value = 5;
+                        UPDATE test SET value = 10;
+                        DELETE test;
 
-                    SELECT * FROM {TABLE};
-                    """
-                )
-            );
-        }
+                        SELECT * FROM test;
+                        """
+                    )
+                );
+            }
+            else
+            {
+                list.Add(
+                    HandleQuery(
+                        $"""
+                        DEFINE TABLE {TABLE};
 
-        return list;
-    }
+                        CREATE {TABLE} SET value = {5};
+                        UPDATE {TABLE} SET value = {10};
+                        DELETE {TABLE};
 
-    [Benchmark]
-    public List<(
-        string,
-        IReadOnlyDictionary<string, object?>
-    )> QueryInterpolatedStringHandlerNoInterpolation()
-    {
-        var list = new List<(string, IReadOnlyDictionary<string, object?>)>(Param);
-
-        for (int index = 0; index < Param; index++)
-        {
-            list.Add(
-                HandleQuery(
-                    $"""
-                    DEFINE TABLE test;
-
-                    CREATE test SET value = 5;
-                    UPDATE test SET value = 10;
-                    DELETE test;
-
-                    SELECT * FROM test;
-                    """
-                )
-            );
+                        SELECT * FROM {TABLE};
+                        """
+                    )
+                );
+            }
         }
 
         return list;

--- a/SurrealDb.Net.Tests/Handlers/QueryInterpolatedStringHandlerTests.cs
+++ b/SurrealDb.Net.Tests/Handlers/QueryInterpolatedStringHandlerTests.cs
@@ -1,0 +1,89 @@
+﻿using SurrealDb.Net.Handlers;
+
+namespace SurrealDb.Net.Tests.Handlers;
+
+public class QueryInterpolatedStringHandlerTests
+{
+    private (string, IReadOnlyDictionary<string, object?>) HandleQuery(
+        QueryInterpolatedStringHandler handler
+    )
+    {
+        return (handler.GetFormattedText(), handler.GetParameters());
+    }
+
+    [Fact]
+    public void ShouldReturnSameStringWithoutArguments()
+    {
+        var (query, @params) = HandleQuery($"DEFINE TABLE test;");
+
+        query.Should().Be("DEFINE TABLE test;");
+        @params.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ShouldExtractQueryWithOneArgument()
+    {
+        int value = 10;
+
+        var (query, @params) = HandleQuery($"CREATE test SET value = {value};");
+
+        query.Should().Be("CREATE test SET value = $p0;");
+
+        var expectedParams = new Dictionary<string, object> { { "p0", value } };
+        @params.Should().BeEquivalentTo(expectedParams);
+    }
+
+    [Fact]
+    public void ShouldExtractQueryWithMultipleArguments()
+    {
+        string table = "test";
+        int value = 10;
+
+        var (query, @params) = HandleQuery($"CREATE {table} SET value = {value};");
+
+        query.Should().Be("CREATE $p0 SET value = $p1;");
+
+        var expectedParams = new Dictionary<string, object> { { "p0", table }, { "p1", value } };
+        @params.Should().BeEquivalentTo(expectedParams);
+    }
+
+    [Fact]
+    public void ShouldAvoidToDuplicateParamsWhenExtractingQueryParams()
+    {
+        string table = "test";
+
+        var (query, @params) = HandleQuery(
+            $"""
+            DEFINE TABLE {table};
+
+            CREATE {table} SET value = {5};
+            UPDATE {table} SET value = {10};
+            DELETE {table};
+
+            SELECT * FROM {table};
+            """
+        );
+
+        query
+            .Should()
+            .Be(
+                """
+                DEFINE TABLE $p0;
+
+                CREATE $p0 SET value = $p1;
+                UPDATE $p0 SET value = $p2;
+                DELETE $p0;
+
+                SELECT * FROM $p0;
+                """
+            );
+
+        var expectedParams = new Dictionary<string, object>
+        {
+            { "p0", table },
+            { "p1", 5 },
+            { "p2", 10 }
+        };
+        @params.Should().BeEquivalentTo(expectedParams);
+    }
+}

--- a/SurrealDb.Net.Tests/Handlers/QueryInterpolatedStringHandlerTests.cs
+++ b/SurrealDb.Net.Tests/Handlers/QueryInterpolatedStringHandlerTests.cs
@@ -8,7 +8,7 @@ public class QueryInterpolatedStringHandlerTests
         QueryInterpolatedStringHandler handler
     )
     {
-        return (handler.GetFormattedText(), handler.GetParameters());
+        return (handler.FormattedText, handler.Parameters);
     }
 
     [Fact]

--- a/SurrealDb.Net.Tests/SurrealDb.Net.Tests.csproj
+++ b/SurrealDb.Net.Tests/SurrealDb.Net.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>

--- a/SurrealDb.Net/Handlers/QueryInterpolatedStringHandler.cs
+++ b/SurrealDb.Net/Handlers/QueryInterpolatedStringHandler.cs
@@ -1,0 +1,55 @@
+﻿#if NET6_0_OR_GREATER
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace SurrealDb.Net.Handlers;
+
+/// <summary>
+/// A custom-tailored <see cref="InterpolatedStringHandlerAttribute"/> to interpret query strings
+/// passed down to <see cref="SurrealDbClient.Query(QueryInterpolatedStringHandler, CancellationToken)"/>.
+/// </summary>
+[InterpolatedStringHandler]
+public readonly ref struct QueryInterpolatedStringHandler
+{
+    private readonly StringBuilder _builder;
+    private readonly Dictionary<string, object?> _parameters = [];
+
+    public QueryInterpolatedStringHandler(int literalLength, int formattedCount)
+    {
+        const int parameterNameExpectedLength = 3;
+        _builder = new(literalLength + parameterNameExpectedLength * formattedCount);
+    }
+
+    public void AppendLiteral(string s)
+    {
+        _builder.Append(s);
+    }
+
+    public void AppendFormatted<T>(T t)
+    {
+        string? parameterName = null;
+
+        foreach (var parameter in _parameters)
+        {
+            if (t?.Equals(parameter.Value) == true)
+            {
+                parameterName = parameter.Key;
+                break;
+            }
+        }
+
+        if (string.IsNullOrEmpty(parameterName))
+        {
+            parameterName = $"p{_parameters.Count}";
+            _parameters.Add(parameterName, t);
+        }
+
+        _builder.Append('$');
+        _builder.Append(parameterName);
+    }
+
+    public string GetFormattedText() => _builder.ToString();
+
+    public IReadOnlyDictionary<string, object?> GetParameters() => _parameters;
+}
+#endif

--- a/SurrealDb.Net/Handlers/QueryInterpolatedStringHandler.cs
+++ b/SurrealDb.Net/Handlers/QueryInterpolatedStringHandler.cs
@@ -25,8 +25,26 @@ public ref struct QueryInterpolatedStringHandler
 
     private static int CalculateParameterNamesExpectedLength(int formattedCount)
     {
-        const int parameterNameExpectedLength = 3;
-        return parameterNameExpectedLength * formattedCount;
+        int totalExpectedLength = 0;
+        int parameterNameExpectedLength = 3;
+
+        int previousMaxNumeralUnits = 0;
+        int currentMaxNumeralUnits = 10;
+
+        while (formattedCount > currentMaxNumeralUnits)
+        {
+            totalExpectedLength +=
+                parameterNameExpectedLength * (currentMaxNumeralUnits - previousMaxNumeralUnits);
+            parameterNameExpectedLength++;
+
+            previousMaxNumeralUnits = currentMaxNumeralUnits;
+            currentMaxNumeralUnits *= 10;
+        }
+
+        totalExpectedLength +=
+            parameterNameExpectedLength * (formattedCount - previousMaxNumeralUnits);
+
+        return totalExpectedLength;
     }
 
     public void AppendLiteral(string s)

--- a/SurrealDb.Net/Handlers/QueryInterpolatedStringHandler.cs
+++ b/SurrealDb.Net/Handlers/QueryInterpolatedStringHandler.cs
@@ -15,6 +15,10 @@ public ref struct QueryInterpolatedStringHandler
     private readonly StringBuilder? _builder;
     private readonly Dictionary<string, object?> _parameters = [];
 
+    public string FormattedText =>
+        _builder is null ? _literalQuery ?? string.Empty : _builder.ToString();
+    public IReadOnlyDictionary<string, object?> Parameters => _parameters;
+
     public QueryInterpolatedStringHandler(int literalLength, int formattedCount)
     {
         if (formattedCount > 0)
@@ -85,10 +89,5 @@ public ref struct QueryInterpolatedStringHandler
         _builder.Append('$');
         _builder.Append(parameterName);
     }
-
-    public string GetFormattedText() =>
-        _builder is null ? _literalQuery ?? string.Empty : _builder.ToString();
-
-    public IReadOnlyDictionary<string, object?> GetParameters() => _parameters;
 }
 #endif

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Http.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Http.cs
@@ -280,14 +280,6 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
         throw new NotSupportedException();
     }
 
-    public Task<SurrealDbLiveQuery<T>> LiveQuery<T>(
-        FormattableString query,
-        CancellationToken cancellationToken
-    )
-    {
-        throw new NotSupportedException();
-    }
-
     public Task<SurrealDbLiveQuery<T>> LiveRawQuery<T>(
         string query,
         IReadOnlyDictionary<string, object?> parameters,
@@ -436,15 +428,6 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
         var dbResponse = await ExecuteRequestAsync(request, cancellationToken)
             .ConfigureAwait(false);
         return dbResponse.DeserializeEnumerable<T>();
-    }
-
-    public async Task<SurrealDbResponse> Query(
-        FormattableString query,
-        CancellationToken cancellationToken
-    )
-    {
-        var (formattedQuery, parameters) = query.ExtractRawQueryParams();
-        return await RawQuery(formattedQuery, parameters, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SurrealDbResponse> RawQuery(

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Interface.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Interface.cs
@@ -36,10 +36,6 @@ public interface ISurrealDbEngine : IDisposable
         CancellationToken cancellationToken
     );
     SurrealDbLiveQuery<T> ListenLive<T>(Guid queryUuid);
-    Task<SurrealDbLiveQuery<T>> LiveQuery<T>(
-        FormattableString query,
-        CancellationToken cancellationToken
-    );
     Task<SurrealDbLiveQuery<T>> LiveRawQuery<T>(
         string query,
         IReadOnlyDictionary<string, object?> parameters,
@@ -87,7 +83,6 @@ public interface ISurrealDbEngine : IDisposable
         CancellationToken cancellationToken
     )
         where T : class;
-    Task<SurrealDbResponse> Query(FormattableString query, CancellationToken cancellationToken);
     Task<SurrealDbResponse> RawQuery(
         string query,
         IReadOnlyDictionary<string, object?> parameters,

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
@@ -545,28 +545,6 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         return new SurrealDbLiveQuery<T>(queryUuid, this);
     }
 
-    public async Task<SurrealDbLiveQuery<T>> LiveQuery<T>(
-        FormattableString query,
-        CancellationToken cancellationToken
-    )
-    {
-        var dbResponse = await Query(query, cancellationToken).ConfigureAwait(false);
-
-        if (dbResponse.HasErrors)
-        {
-            throw new SurrealDbErrorResultException(dbResponse.FirstError!);
-        }
-
-        if (dbResponse.FirstOk is null)
-        {
-            throw new SurrealDbErrorResultException();
-        }
-
-        var queryUuid = dbResponse.FirstOk.GetValue<Guid>()!;
-
-        return ListenLive<T>(queryUuid);
-    }
-
     public async Task<SurrealDbLiveQuery<T>> LiveRawQuery<T>(
         string query,
         IReadOnlyDictionary<string, object?> parameters,
@@ -721,15 +699,6 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         var dbResponse = await SendRequestAsync("patch", [table, patches], true, cancellationToken)
             .ConfigureAwait(false);
         return dbResponse.DeserializeEnumerable<T>();
-    }
-
-    public async Task<SurrealDbResponse> Query(
-        FormattableString query,
-        CancellationToken cancellationToken
-    )
-    {
-        var (formattedQuery, parameters) = query.ExtractRawQueryParams();
-        return await RawQuery(formattedQuery, parameters, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SurrealDbResponse> RawQuery(

--- a/SurrealDb.Net/SurrealDb.Net.csproj
+++ b/SurrealDb.Net/SurrealDb.Net.csproj
@@ -36,6 +36,12 @@
   <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
     <_Parameter1>SurrealDb.Net.Benchmarks.Remote</_Parameter1>
   </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>SurrealDb.Net.LocalBenchmarks</_Parameter1>
+    </AssemblyAttribute>
+	<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+	  <_Parameter1>SurrealDb.Reactive</_Parameter1>
+	</AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">

--- a/SurrealDb.Net/SurrealDbClient.Interface.cs
+++ b/SurrealDb.Net/SurrealDbClient.Interface.cs
@@ -4,6 +4,9 @@ using SurrealDb.Net.Models.Auth;
 using SurrealDb.Net.Models.LiveQuery;
 using SurrealDb.Net.Models.Response;
 using SystemTextJsonPatch;
+#if NET6_0_OR_GREATER
+using SurrealDb.Net.Handlers;
+#endif
 
 namespace SurrealDb.Net;
 
@@ -218,7 +221,11 @@ public interface ISurrealDbClient : IDisposable
     /// <exception cref="OperationCanceledException"></exception>
     /// <exception cref="SurrealDbException"></exception>
     Task<SurrealDbLiveQuery<T>> LiveQuery<T>(
+#if NET6_0_OR_GREATER
+        QueryInterpolatedStringHandler query,
+#else
         FormattableString query,
+#endif
         CancellationToken cancellationToken = default
     );
 
@@ -408,7 +415,11 @@ public interface ISurrealDbClient : IDisposable
     /// <exception cref="InvalidOperationException"></exception>
     /// <exception cref="SurrealDbException"></exception>
     Task<SurrealDbResponse> Query(
+#if NET6_0_OR_GREATER
+        QueryInterpolatedStringHandler query,
+#else
         FormattableString query,
+#endif
         CancellationToken cancellationToken = default
     );
 

--- a/SurrealDb.Net/SurrealDbClient.cs
+++ b/SurrealDb.Net/SurrealDbClient.cs
@@ -265,11 +265,7 @@ public class SurrealDbClient : ISurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return _engine.LiveRawQuery<T>(
-            query.GetFormattedText(),
-            query.GetParameters(),
-            cancellationToken
-        );
+        return _engine.LiveRawQuery<T>(query.FormattedText, query.Parameters, cancellationToken);
     }
 #else
     public Task<SurrealDbLiveQuery<T>> LiveQuery<T>(
@@ -386,7 +382,7 @@ public class SurrealDbClient : ISurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return _engine.RawQuery(query.GetFormattedText(), query.GetParameters(), cancellationToken);
+        return _engine.RawQuery(query.FormattedText, query.Parameters, cancellationToken);
     }
 #else
     public Task<SurrealDbResponse> Query(

--- a/SurrealDb.Reactive/Extensions/SurrealDbClientExtensions.cs
+++ b/SurrealDb.Reactive/Extensions/SurrealDbClientExtensions.cs
@@ -2,6 +2,11 @@
 using SurrealDb.Net.Exceptions;
 using SurrealDb.Net.Models.LiveQuery;
 using SurrealDb.Net.Models.Response;
+#if NET6_0_OR_GREATER
+using SurrealDb.Net.Handlers;
+#else
+using SurrealDb.Net.Internals.Extensions;
+#endif
 
 namespace SurrealDb.Net;
 
@@ -18,66 +23,21 @@ public static class SurrealDbClientExtensions
     /// <returns>Returns an Observable to consume incoming live query notification.</returns>
     public static IObservable<SurrealDbLiveQueryResponse> ObserveQuery<T>(
         this ISurrealDbClient client,
+#if NET6_0_OR_GREATER
+        QueryInterpolatedStringHandler query
+#else
         FormattableString query
+#endif
     )
     {
-        return Observable.Defer(
-            () =>
-                Observable.Create<SurrealDbLiveQueryResponse>(
-                    async (observer, cancellationToken) =>
-                    {
-                        SurrealDbResponse response = null!;
+#if NET6_0_OR_GREATER
+        string formattedQuery = query.GetFormattedText();
+        var parameters = query.GetParameters();
+#else
+        var (formattedQuery, parameters) = query.ExtractRawQueryParams();
+#endif
 
-                        try
-                        {
-                            response = await client.Query(query, cancellationToken);
-                        }
-                        catch (Exception e)
-                        {
-                            observer.OnError(e);
-                            return () => { };
-                        }
-
-                        if (response.HasErrors)
-                        {
-                            observer.OnError(
-                                new SurrealDbErrorResultException(response.FirstError!)
-                            );
-                            return () => { };
-                        }
-
-                        if (response.FirstOk is null)
-                        {
-                            observer.OnError(new SurrealDbErrorResultException());
-                            return () => { };
-                        }
-
-                        // TODO : handle multi-queries
-
-                        SurrealDbLiveQuery<T> liveQuery = null!;
-
-                        var queryUuid = response.FirstOk!.GetValue<Guid>();
-
-                        try
-                        {
-                            liveQuery = client.ListenLive<T>(queryUuid);
-                        }
-                        catch (Exception e)
-                        {
-                            observer.OnError(e);
-                            return () => { };
-                        }
-
-                        var subscription = liveQuery.ToObservable().Subscribe(observer);
-
-                        return () =>
-                        {
-                            subscription.Dispose();
-                            liveQuery.DisposeAsync().GetAwaiter().GetResult();
-                        };
-                    }
-                )
-        );
+        return client.ObserveRawQuery<T>(formattedQuery, parameters);
     }
 
     /// <summary>

--- a/SurrealDb.Reactive/Extensions/SurrealDbClientExtensions.cs
+++ b/SurrealDb.Reactive/Extensions/SurrealDbClientExtensions.cs
@@ -31,8 +31,8 @@ public static class SurrealDbClientExtensions
     )
     {
 #if NET6_0_OR_GREATER
-        string formattedQuery = query.GetFormattedText();
-        var parameters = query.GetParameters();
+        string formattedQuery = query.FormattedText;
+        var parameters = query.Parameters;
 #else
         var (formattedQuery, parameters) = query.ExtractRawQueryParams();
 #endif


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Create and use a custom `InterpolatedStringHandler` for `Query` methods to improve performance.
Also removed duplicated code from engines by reusing `RawX` method versions.

For a typical scenario, the benchmark confirms the performance improvements: more than 2x faster & slightly less memory allocation. See:

```
BenchmarkDotNet v0.13.10, Windows 11 (10.0.22631.3880/23H2/2023Update/SunValley3)
AMD Ryzen 9 5900X, 1 CPU, 24 logical and 12 physical cores
.NET SDK 8.0.400-preview.0.24324.5
  [Host]     : .NET 8.0.7 (8.0.724.31311), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.7 (8.0.724.31311), X64 RyuJIT AVX2


| Method                         | Count | Mode            | Mean         | Error      | StdDev     | Gen0   | Gen1   | Allocated |
|------------------------------- |------ |---------------- |-------------:|-----------:|-----------:|-------:|-------:|----------:|
| FormattableString              | 1     | Interpolation   |    570.19 ns |   3.096 ns |   2.586 ns | 0.0706 |      - |    1192 B |
| QueryInterpolatedStringHandler | 1     | Interpolation   |    259.67 ns |   1.456 ns |   1.216 ns | 0.0582 |      - |     976 B |
| FormattableString              | 1     | NoInterpolation |     18.70 ns |   0.132 ns |   0.117 ns | 0.0062 |      - |     104 B |
| QueryInterpolatedStringHandler | 1     | NoInterpolation |     26.12 ns |   0.309 ns |   0.289 ns | 0.0091 |      - |     152 B |
| FormattableString              | 100   | Interpolation   | 56,620.39 ns | 136.167 ns | 106.310 ns | 6.7749 | 1.2207 |  113656 B |
| QueryInterpolatedStringHandler | 100   | Interpolation   | 24,738.14 ns | 317.446 ns | 281.407 ns | 5.4932 | 1.0376 |   92056 B |
| FormattableString              | 100   | NoInterpolation |  1,337.70 ns |  19.816 ns |  16.547 ns | 0.2899 |      - |    4856 B |
| QueryInterpolatedStringHandler | 100   | NoInterpolation |  2,090.98 ns |  13.691 ns |  12.806 ns | 0.5760 | 0.0191 |    9656 B |
```

## What does this change do?

Provide a description of what this pull request does.

## What is your testing strategy?

Unit tests + benchmarks

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)