### PR TITLE
✨ implement reconnect pattern for ws protocol

### DIFF
--- a/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Net.WebSockets;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
@@ -1045,6 +1045,12 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         CancellationToken cancellationToken
     )
     {
+        using var timeoutCts = new CancellationTokenSource();
+        var timeoutTask = Task.Delay(30_000, cancellationToken);
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+        Task.Run(async () => await timeoutTask.ConfigureAwait(false), timeoutCts.Token);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+
         await InternalConnectAsync(requireInitialized, cancellationToken).ConfigureAwait(false);
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -1114,14 +1120,23 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 
         if (!isMessageSent)
         {
+            timeoutCts.Cancel();
             taskCompletionSource.SetException(new SurrealDbException("Failed to send message"));
             throw new SurrealDbException("Failed to send message");
         }
 
-        var response = await taskCompletionSource.Task.ConfigureAwait(false);
+        var completedTask = await Task.WhenAny(taskCompletionSource.Task, timeoutTask)
+            .ConfigureAwait(false);
+
         cancellationToken.ThrowIfCancellationRequested();
 
-        return response;
+        if (completedTask == taskCompletionSource.Task)
+        {
+            return await taskCompletionSource.Task.ConfigureAwait(false);
+        }
+
+        taskCompletionSource.TrySetCanceled(CancellationToken.None);
+        throw new TimeoutException();
     }
 
     private static async Task CloseLiveQueryAsync(

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Net.WebSockets;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
@@ -52,10 +52,6 @@ internal partial class SurrealDbWsJsonSerializerContext : JsonSerializerContext;
 internal class SurrealDbWsEngine : ISurrealDbEngine
 {
     private static readonly ConcurrentDictionary<string, SurrealDbWsEngine> _wsEngines = new();
-    private static readonly ConcurrentDictionary<
-        string,
-        SurrealWsTaskCompletionSource
-    > _responseTasks = new();
 
     private readonly bool _useCbor;
     private readonly string _id;
@@ -72,6 +68,8 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         SurrealDbLiveQueryChannelSubscriptions
     > _liveQueryChannelSubscriptionsPerQuery = new();
     private readonly Pinger _pinger;
+    private readonly WsResponseTaskHandler _responseTaskHandler;
+    private readonly SemaphoreSlim _semaphoreConnect = new(1, 1);
 
     private bool _isInitialized;
 
@@ -112,9 +110,11 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         _wsClient = new WebsocketClient(new Uri(parameters.Endpoint!), clientWebSocketFactory)
         {
             IsTextMessageConversionEnabled = false,
-            IsStreamDisposedAutomatically = false
+            IsStreamDisposedAutomatically = false,
+            ErrorReconnectTimeout = TimeSpan.FromSeconds(10),
         };
         _pinger = new(Ping);
+        _responseTaskHandler = new(id);
 
         _receiverSubscription = _wsClient
             .MessageReceived.ObserveOn(TaskPoolScheduler.Default)
@@ -246,7 +246,7 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 
                         if (
                             response is ISurrealDbWsStandardResponse surrealDbWsStandardResponse
-                            && _responseTasks.TryRemove(
+                            && _responseTaskHandler.TryRemove(
                                 surrealDbWsStandardResponse.Id,
                                 out var responseTaskCompletionSource
                             )
@@ -274,11 +274,70 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
             )
             .Merge()
             .Subscribe();
+
+        _wsClient
+            .ReconnectionHappened.Where(info => info.Type != ReconnectionType.Initial)
+            .Select(_ =>
+                Observable.FromAsync(
+                    async (cancellationToken) =>
+                    {
+                        await ApplyConfigurationAsync(cancellationToken).ConfigureAwait(false);
+                    }
+                )
+            )
+            .Switch()
+            .Subscribe();
+
+        _wsClient.DisconnectionHappened.Subscribe(
+            async (_) =>
+            {
+                var endChannelsTasks = new List<Task>();
+
+                foreach (var (key, value) in _liveQueryChannelSubscriptionsPerQuery)
+                {
+                    if (
+                        value.WsEngineId == _id
+                        && _liveQueryChannelSubscriptionsPerQuery.TryRemove(
+                            key,
+                            out var _liveQueryChannelSubscriptions
+                        )
+                    )
+                    {
+                        foreach (var liveQueryChannel in _liveQueryChannelSubscriptions)
+                        {
+                            var closeTask = CloseLiveQueryAsync(
+                                liveQueryChannel,
+                                SurrealDbLiveQueryClosureReason.SocketClosed
+                            );
+                            endChannelsTasks.Add(closeTask);
+                        }
+                    }
+                }
+
+                if (endChannelsTasks.Count > 0)
+                {
+                    try
+                    {
+                        await Task.WhenAll(endChannelsTasks).ConfigureAwait(false);
+                    }
+                    catch { }
+                }
+            }
+        );
     }
 
-    public async Task Authenticate(Jwt jwt, CancellationToken cancellationToken)
+    public Task Authenticate(Jwt jwt, CancellationToken cancellationToken)
     {
-        await SendRequestAsync("authenticate", [jwt.Token], false, cancellationToken)
+        return Authenticate(jwt, SurrealDbWsRequestPriority.Normal, cancellationToken);
+    }
+
+    private async Task Authenticate(
+        Jwt jwt,
+        SurrealDbWsRequestPriority priority,
+        CancellationToken cancellationToken
+    )
+    {
+        await SendRequestAsync("authenticate", [jwt.Token], priority, cancellationToken)
             .ConfigureAwait(false);
     }
 
@@ -311,29 +370,12 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 
         await _wsClient.StartOrFail().ConfigureAwait(false);
 
-        if (_config.Ns is not null)
-        {
-            await Use(_config.Ns, _config.Db!, cancellationToken).ConfigureAwait(false);
-        }
-
-        if (_config.Auth is BasicAuth basicAuth)
-        {
-            await SignIn(
-                    new RootAuth { Username = basicAuth.Username, Password = basicAuth.Password! },
-                    cancellationToken
-                )
-                .ConfigureAwait(false);
-        }
-
-        if (_config.Auth is BearerAuth bearerAuth)
-        {
-            await Authenticate(new Jwt { Token = bearerAuth.Token }, cancellationToken)
-                .ConfigureAwait(false);
-        }
+        await ApplyConfigurationAsync(cancellationToken).ConfigureAwait(false);
 
         if (_useCbor)
         {
-            string version = await Version(cancellationToken).ConfigureAwait(false);
+            string version = await Version(SurrealDbWsRequestPriority.High, cancellationToken)
+                .ConfigureAwait(false);
             if (version.ToSemver().CompareSortOrderTo(new SemVersion(1, 4, 0)) < 0)
             {
                 throw new SurrealDbException("CBOR is only supported on SurrealDB 1.4.0 or later.");
@@ -352,14 +394,24 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 
         object?[] @params = _useCbor ? [data.Id, data] : [data.Id.ToString(), data];
 
-        var dbResponse = await SendRequestAsync("create", @params, true, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "create",
+                @params,
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
         return dbResponse.GetValue<T>()!;
     }
 
     public async Task<T> Create<T>(string table, T? data, CancellationToken cancellationToken)
     {
-        var dbResponse = await SendRequestAsync("create", [table, data], true, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "create",
+                [table, data],
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
 
         return dbResponse.DeserializeEnumerable<T>().First();
@@ -379,21 +431,37 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
             );
         }
 
-        var dbResponse = await SendRequestAsync("create", [recordId, data], true, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "create",
+                [recordId, data],
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
         return dbResponse.GetValue<TOutput>()!;
     }
 
     public async Task Delete(string table, CancellationToken cancellationToken)
     {
-        await SendRequestAsync("delete", [table], true, cancellationToken).ConfigureAwait(false);
+        await SendRequestAsync(
+                "delete",
+                [table],
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
     }
 
     public async Task<bool> Delete(Thing thing, CancellationToken cancellationToken)
     {
         object?[] @params = _useCbor ? [thing] : [thing.ToString()];
 
-        var dbResponse = await SendRequestAsync("delete", @params, true, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "delete",
+                @params,
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
 
         if (dbResponse.Result.HasValue)
@@ -414,7 +482,12 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
             );
         }
 
-        var dbResponse = await SendRequestAsync("delete", [recordId], true, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "delete",
+                [recordId],
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
 
         if (dbResponse.Result.HasValue)
@@ -456,7 +529,7 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
             }
         }
 
-        if (endChannelsTasks.Any())
+        if (endChannelsTasks.Count > 0)
         {
             try
             {
@@ -469,20 +542,16 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         _wsClient.Stop(WebSocketCloseStatus.NormalClosure, "Client disposed");
         _receiverSubscription.Dispose();
 
-        foreach (var (key, value) in _responseTasks)
+        foreach (var (key, value) in _responseTaskHandler)
         {
-            if (
-                value.WsEngineId == _id
-                && _responseTasks.TryRemove(key, out var responseTaskCompletionSource)
-            )
-            {
-                responseTaskCompletionSource.TrySetCanceled();
-            }
+            _responseTaskHandler.TryRemove(key, out _);
+            value.TrySetCanceled();
         }
 
         _wsEngines.TryRemove(_id, out _);
 
         _wsClient.Dispose();
+        _semaphoreConnect.Dispose();
     }
 
     public async Task<bool> Health(CancellationToken cancellationToken)
@@ -503,14 +572,25 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 
     public async Task<T> Info<T>(CancellationToken cancellationToken)
     {
-        var dbResponse = await SendRequestAsync("info", null, true, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "info",
+                null,
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
         return dbResponse.GetValue<T>()!;
     }
 
     public async Task Invalidate(CancellationToken cancellationToken)
     {
-        await SendRequestAsync("invalidate", null, false, cancellationToken).ConfigureAwait(false);
+        await SendRequestAsync(
+                "invalidate",
+                null,
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
     }
 
     public async Task Kill(
@@ -536,7 +616,13 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 
         object?[] @params = _useCbor ? [queryUuid] : [queryUuid.ToString()];
 
-        await SendRequestAsync("kill", @params, true, cancellationToken).ConfigureAwait(false);
+        await SendRequestAsync(
+                "kill",
+                @params,
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
     }
 
     public SurrealDbLiveQuery<T> ListenLive<T>(Guid queryUuid)
@@ -596,7 +682,12 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         CancellationToken cancellationToken
     )
     {
-        var dbResponse = await SendRequestAsync("live", [table, diff], true, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "live",
+                [table, diff],
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
         var queryUuid = dbResponse.GetValue<Guid>()!;
 
@@ -614,7 +705,12 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 
         object?[] @params = _useCbor ? [data.Id, data] : [data.Id.ToWsString(), data];
 
-        var dbResponse = await SendRequestAsync("merge", @params, true, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "merge",
+                @params,
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
         return dbResponse.GetValue<TOutput>()!;
     }
@@ -627,7 +723,12 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     {
         object?[] @params = _useCbor ? [thing, data] : [thing.ToWsString(), data];
 
-        var dbResponse = await SendRequestAsync("merge", @params, true, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "merge",
+                @params,
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
         return dbResponse.GetValue<T>()!;
     }
@@ -645,7 +746,12 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
             );
         }
 
-        var dbResponse = await SendRequestAsync("merge", [recordId, data], true, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "merge",
+                [recordId, data],
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
         return dbResponse.GetValue<T>()!;
     }
@@ -657,7 +763,12 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     )
         where TMerge : class
     {
-        var dbResponse = await SendRequestAsync("merge", [table, data], true, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "merge",
+                [table, data],
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
         return dbResponse.DeserializeEnumerable<TOutput>();
     }
@@ -668,7 +779,12 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         CancellationToken cancellationToken
     )
     {
-        var dbResponse = await SendRequestAsync("merge", [table, data], true, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "merge",
+                [table, data],
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
         return dbResponse.DeserializeEnumerable<T>();
     }
@@ -682,7 +798,12 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     {
         object?[] @params = _useCbor ? [thing, patches] : [thing.ToWsString(), patches];
 
-        var dbResponse = await SendRequestAsync("patch", @params, true, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "patch",
+                @params,
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
         return dbResponse.GetValue<T>()!;
     }
@@ -704,7 +825,7 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         var dbResponse = await SendRequestAsync(
                 "patch",
                 [recordId, patches],
-                true,
+                SurrealDbWsRequestPriority.Normal,
                 cancellationToken
             )
             .ConfigureAwait(false);
@@ -718,7 +839,12 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     )
         where T : class
     {
-        var dbResponse = await SendRequestAsync("patch", [table, patches], true, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "patch",
+                [table, patches],
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
         return dbResponse.DeserializeEnumerable<T>();
     }
@@ -741,7 +867,7 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         var dbResponse = await SendRequestAsync(
                 "query",
                 [query, parameters],
-                true,
+                SurrealDbWsRequestPriority.Normal,
                 cancellationToken
             )
             .ConfigureAwait(false);
@@ -762,7 +888,7 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         var dbResponse = await SendRequestAsync(
                 "relate",
                 [ins, table, outs, data],
-                true,
+                SurrealDbWsRequestPriority.Normal,
                 cancellationToken
             )
             .ConfigureAwait(false);
@@ -782,7 +908,7 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         var dbResponse = await SendRequestAsync(
                 "relate",
                 [@in, thing, @out, data],
-                true,
+                SurrealDbWsRequestPriority.Normal,
                 cancellationToken
             )
             .ConfigureAwait(false);
@@ -792,7 +918,12 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 
     public async Task<IEnumerable<T>> Select<T>(string table, CancellationToken cancellationToken)
     {
-        var dbResponse = await SendRequestAsync("select", [table], true, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "select",
+                [table],
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
         return dbResponse.DeserializeEnumerable<T>()!;
     }
@@ -801,7 +932,12 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     {
         object?[] @params = _useCbor ? [thing] : [thing.ToWsString()];
 
-        var dbResponse = await SendRequestAsync("select", @params, true, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "select",
+                @params,
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
         return dbResponse.GetValue<T?>();
     }
@@ -815,7 +951,12 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
             );
         }
 
-        var dbResponse = await SendRequestAsync("select", [recordId], true, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "select",
+                [recordId],
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
         return dbResponse.GetValue<T?>();
     }
@@ -831,29 +972,60 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
             throw new ArgumentException("Variable name is not valid.", nameof(key));
         }
 
-        await SendRequestAsync("let", [key, value], false, cancellationToken).ConfigureAwait(false);
+        await SendRequestAsync(
+                "let",
+                [key, value],
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
     }
 
-    public async Task SignIn(RootAuth rootAuth, CancellationToken cancellationToken)
+    public Task SignIn(RootAuth rootAuth, CancellationToken cancellationToken)
     {
-        await SendRequestAsync("signin", [rootAuth], false, cancellationToken)
+        return SignIn(rootAuth, SurrealDbWsRequestPriority.Normal, cancellationToken);
+    }
+
+    private async Task SignIn(
+        RootAuth rootAuth,
+        SurrealDbWsRequestPriority priority,
+        CancellationToken cancellationToken
+    )
+    {
+        await SendRequestAsync("signin", [rootAuth], priority, cancellationToken)
             .ConfigureAwait(false);
+
+        _config.SetBasicAuth(rootAuth.Username, rootAuth.Password);
     }
 
     public async Task<Jwt> SignIn(NamespaceAuth nsAuth, CancellationToken cancellationToken)
     {
-        var dbResponse = await SendRequestAsync("signin", [nsAuth], false, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "signin",
+                [nsAuth],
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
         var token = dbResponse.GetValue<string>();
+
+        _config.SetBearerAuth(token!);
 
         return new Jwt { Token = token! };
     }
 
     public async Task<Jwt> SignIn(DatabaseAuth dbAuth, CancellationToken cancellationToken)
     {
-        var dbResponse = await SendRequestAsync("signin", [dbAuth], false, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "signin",
+                [dbAuth],
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
         var token = dbResponse.GetValue<string>();
+
+        _config.SetBearerAuth(token!);
 
         return new Jwt { Token = token! };
     }
@@ -861,9 +1033,16 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     public async Task<Jwt> SignIn<T>(T scopeAuth, CancellationToken cancellationToken)
         where T : ScopeAuth
     {
-        var dbResponse = await SendRequestAsync("signin", [scopeAuth], false, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "signin",
+                [scopeAuth],
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
         var token = dbResponse.GetValue<string>();
+
+        _config.SetBearerAuth(token!);
 
         return new Jwt { Token = token! };
     }
@@ -871,9 +1050,16 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     public async Task<Jwt> SignUp<T>(T scopeAuth, CancellationToken cancellationToken)
         where T : ScopeAuth
     {
-        var dbResponse = await SendRequestAsync("signup", [scopeAuth], false, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "signup",
+                [scopeAuth],
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
         var token = dbResponse.GetValue<string>();
+
+        _config.SetBearerAuth(token!);
 
         return new Jwt { Token = token! };
     }
@@ -907,7 +1093,8 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
             throw new ArgumentException("Variable name is not valid.", nameof(key));
         }
 
-        await SendRequestAsync("unset", [key], false, cancellationToken).ConfigureAwait(false);
+        await SendRequestAsync("unset", [key], SurrealDbWsRequestPriority.Normal, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     public async Task<IEnumerable<T>> UpdateAll<T>(
@@ -917,7 +1104,12 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     )
         where T : class
     {
-        var dbResponse = await SendRequestAsync("update", [table, data], true, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "update",
+                [table, data],
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
         return dbResponse.DeserializeEnumerable<T>();
     }
@@ -930,7 +1122,12 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 
         object?[] @params = _useCbor ? [data.Id, data] : [data.Id.ToWsString(), data];
 
-        var dbResponse = await SendRequestAsync("update", @params, true, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "update",
+                @params,
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
         return dbResponse.GetValue<T>()!;
     }
@@ -949,19 +1146,43 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
             );
         }
 
-        var dbResponse = await SendRequestAsync("update", [recordId, data], true, cancellationToken)
+        var dbResponse = await SendRequestAsync(
+                "update",
+                [recordId, data],
+                SurrealDbWsRequestPriority.Normal,
+                cancellationToken
+            )
             .ConfigureAwait(false);
         return dbResponse.GetValue<TOutput>()!;
     }
 
-    public async Task Use(string ns, string db, CancellationToken cancellationToken)
+    public Task Use(string ns, string db, CancellationToken cancellationToken)
     {
-        await SendRequestAsync("use", [ns, db], false, cancellationToken).ConfigureAwait(false);
+        return Use(ns, db, SurrealDbWsRequestPriority.Normal, cancellationToken);
     }
 
-    public async Task<string> Version(CancellationToken cancellationToken)
+    private async Task Use(
+        string ns,
+        string db,
+        SurrealDbWsRequestPriority priority,
+        CancellationToken cancellationToken
+    )
     {
-        var dbResponse = await SendRequestAsync("version", null, false, cancellationToken)
+        await SendRequestAsync("use", [ns, db], priority, cancellationToken).ConfigureAwait(false);
+        _config.Use(ns, db);
+    }
+
+    public Task<string> Version(CancellationToken cancellationToken)
+    {
+        return Version(SurrealDbWsRequestPriority.Normal, cancellationToken);
+    }
+
+    private async Task<string> Version(
+        SurrealDbWsRequestPriority priority,
+        CancellationToken cancellationToken
+    )
+    {
+        var dbResponse = await SendRequestAsync("version", null, priority, cancellationToken)
             .ConfigureAwait(false);
         string version = dbResponse.GetValue<string>()!;
 
@@ -1001,15 +1222,43 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         );
     }
 
+    private async Task ApplyConfigurationAsync(CancellationToken cancellationToken)
+    {
+        if (_config.Ns is not null)
+        {
+            await Use(_config.Ns, _config.Db!, SurrealDbWsRequestPriority.High, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        if (_config.Auth is BasicAuth basicAuth)
+        {
+            await SignIn(
+                    new RootAuth { Username = basicAuth.Username, Password = basicAuth.Password! },
+                    SurrealDbWsRequestPriority.High,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+        }
+
+        if (_config.Auth is BearerAuth bearerAuth)
+        {
+            await Authenticate(
+                    new Jwt { Token = bearerAuth.Token },
+                    SurrealDbWsRequestPriority.High,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+        }
+    }
+
     private async Task Ping(CancellationToken cancellationToken)
     {
         if (_wsClient.IsStarted)
         {
-            await SendRequestAsync("ping", null, false, cancellationToken).ConfigureAwait(false);
+            await SendRequestAsync("ping", null, SurrealDbWsRequestPriority.High, cancellationToken)
+                .ConfigureAwait(false);
         }
     }
-
-    private readonly SemaphoreSlim _semaphoreConnect = new(1, 1);
 
     /// <summary>
     /// Avoid multiple connections in a multi-threading context
@@ -1022,10 +1271,10 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     {
         if (!_wsClient.IsStarted || (requireInitialized && !_isInitialized))
         {
-            await _semaphoreConnect.WaitAsync(cancellationToken).ConfigureAwait(false);
-
             try
             {
+                await _semaphoreConnect.WaitAsync(cancellationToken).ConfigureAwait(false);
+
                 if (!_wsClient.IsStarted)
                 {
                     await Connect(cancellationToken).ConfigureAwait(false);
@@ -1041,7 +1290,7 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     private async Task<SurrealDbWsOkResponse> SendRequestAsync(
         string method,
         object?[]? parameters,
-        bool requireInitialized,
+        SurrealDbWsRequestPriority priority,
         CancellationToken cancellationToken
     )
     {
@@ -1051,11 +1300,16 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         Task.Run(async () => await timeoutTask.ConfigureAwait(false), timeoutCts.Token);
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 
+        bool requireInitialized = priority == SurrealDbWsRequestPriority.Normal;
         await InternalConnectAsync(requireInitialized, cancellationToken).ConfigureAwait(false);
 
-        cancellationToken.ThrowIfCancellationRequested();
+        if (cancellationToken.IsCancellationRequested)
+        {
+            timeoutCts.Cancel();
+            cancellationToken.ThrowIfCancellationRequested();
+        }
 
-        var taskCompletionSource = new SurrealWsTaskCompletionSource(_id);
+        var taskCompletionSource = new SurrealWsTaskCompletionSource(priority);
 
         string id;
 
@@ -1063,7 +1317,18 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         do
         {
             id = RandomHelper.CreateRandomId();
-        } while (!_responseTasks.TryAdd(id, taskCompletionSource));
+        } while (!_responseTaskHandler.TryAdd(id, priority, taskCompletionSource));
+
+        var waitUntilTask = _responseTaskHandler.WaitUntilAsync(priority, cancellationToken);
+
+        var initialTask = await Task.WhenAny(waitUntilTask, timeoutTask).ConfigureAwait(false);
+
+        if (initialTask != waitUntilTask)
+        {
+            _responseTaskHandler.TryRemove(id, out _);
+            taskCompletionSource.TrySetCanceled(CancellationToken.None);
+            throw new TimeoutException();
+        }
 
         bool shouldSendParamsInRequest = parameters is not null && parameters.Length > 0;
 
@@ -1121,20 +1386,29 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         if (!isMessageSent)
         {
             timeoutCts.Cancel();
-            taskCompletionSource.SetException(new SurrealDbException("Failed to send message"));
+            _responseTaskHandler.TryRemove(id, out _);
+            taskCompletionSource.TrySetCanceled(CancellationToken.None);
             throw new SurrealDbException("Failed to send message");
         }
 
         var completedTask = await Task.WhenAny(taskCompletionSource.Task, timeoutTask)
             .ConfigureAwait(false);
 
-        cancellationToken.ThrowIfCancellationRequested();
+        if (cancellationToken.IsCancellationRequested)
+        {
+            timeoutCts.Cancel();
+            _responseTaskHandler.TryRemove(id, out _);
+            taskCompletionSource.TrySetCanceled(CancellationToken.None);
+            cancellationToken.ThrowIfCancellationRequested();
+        }
 
         if (completedTask == taskCompletionSource.Task)
         {
+            timeoutCts.Cancel();
             return await taskCompletionSource.Task.ConfigureAwait(false);
         }
 
+        _responseTaskHandler.TryRemove(id, out _);
         taskCompletionSource.TrySetCanceled(CancellationToken.None);
         throw new TimeoutException();
     }

--- a/SurrealDb.Net/Internals/Ws/Pinger.cs
+++ b/SurrealDb.Net/Internals/Ws/Pinger.cs
@@ -60,7 +60,11 @@ internal class Pinger : IDisposable
                     .ConfigureAwait(false)
             )
             {
-                await _pingCallback(default).ConfigureAwait(false);
+                try
+                {
+                    await _pingCallback(default).ConfigureAwait(false);
+                }
+                catch { }
             }
         }
         catch (OperationCanceledException) { }

--- a/SurrealDb.Net/Internals/Ws/SurrealDbWsRequestPriority.cs
+++ b/SurrealDb.Net/Internals/Ws/SurrealDbWsRequestPriority.cs
@@ -1,0 +1,7 @@
+﻿namespace SurrealDb.Net.Internals.Ws;
+
+internal enum SurrealDbWsRequestPriority
+{
+    Normal,
+    High,
+}

--- a/SurrealDb.Net/Internals/Ws/SurrealWsTaskCompletionSource.cs
+++ b/SurrealDb.Net/Internals/Ws/SurrealWsTaskCompletionSource.cs
@@ -1,11 +1,11 @@
-namespace SurrealDb.Net.Internals.Ws;
+﻿namespace SurrealDb.Net.Internals.Ws;
 
 internal class SurrealWsTaskCompletionSource : TaskCompletionSource<SurrealDbWsOkResponse>
 {
-    public string WsEngineId { get; }
+    public SurrealDbWsRequestPriority Priority { get; }
 
-    public SurrealWsTaskCompletionSource(string wsEngineId)
+    public SurrealWsTaskCompletionSource(SurrealDbWsRequestPriority priority)
     {
-        WsEngineId = wsEngineId;
+        Priority = priority;
     }
 }

--- a/SurrealDb.Net/Internals/Ws/WsResponseTaskHandler.cs
+++ b/SurrealDb.Net/Internals/Ws/WsResponseTaskHandler.cs
@@ -1,0 +1,143 @@
+﻿using System.Collections;
+using System.Collections.Concurrent;
+using ConcurrentCollections;
+
+namespace SurrealDb.Net.Internals.Ws;
+
+internal class WsResponseTaskHandler
+    : IEnumerable<KeyValuePair<string, SurrealWsTaskCompletionSource>>
+{
+    private static readonly ConcurrentHashSet<string> _allResponseTaskIds = [];
+
+    private readonly string _engineId;
+    private readonly ConcurrentDictionary<
+        string,
+        SurrealWsTaskCompletionSource
+    > _highResponseTasks = new();
+    private readonly ConcurrentDictionary<
+        string,
+        SurrealWsTaskCompletionSource
+    > _normalResponseTasks = new();
+    private readonly ConcurrentDictionary<
+        SurrealDbWsRequestPriority,
+        TaskCompletionSource<bool>
+    > _queueSources =
+        new(
+            [
+                new(SurrealDbWsRequestPriority.High, new()),
+                new(SurrealDbWsRequestPriority.Normal, new()),
+            ]
+        );
+
+    private SurrealDbWsRequestPriority? _currentPriority;
+
+    public WsResponseTaskHandler(string engineId)
+    {
+        _engineId = engineId;
+    }
+
+    public IEnumerator<KeyValuePair<string, SurrealWsTaskCompletionSource>> GetEnumerator()
+    {
+        foreach (var responseTask in _highResponseTasks)
+        {
+            yield return responseTask;
+        }
+        foreach (var responseTask in _normalResponseTasks)
+        {
+            yield return responseTask;
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    private ConcurrentDictionary<string, SurrealWsTaskCompletionSource> GetResponseTasksByPriority(
+        SurrealDbWsRequestPriority priority
+    )
+    {
+        return priority switch
+        {
+            SurrealDbWsRequestPriority.High => _highResponseTasks,
+            SurrealDbWsRequestPriority.Normal => _normalResponseTasks,
+            _ => throw new ArgumentOutOfRangeException(nameof(priority)),
+        };
+    }
+
+    private void UpdateQueueSources()
+    {
+        SurrealDbWsRequestPriority? nextPriority = _highResponseTasks.IsEmpty
+            ? _normalResponseTasks.IsEmpty
+                ? null
+                : SurrealDbWsRequestPriority.Normal
+            : SurrealDbWsRequestPriority.High;
+
+        if (nextPriority != _currentPriority)
+        {
+            if (nextPriority.HasValue)
+            {
+                _queueSources.GetValueOrDefault(nextPriority.Value)?.TrySetResult(true);
+            }
+            if (_currentPriority.HasValue)
+            {
+                _queueSources.TryRemove(_currentPriority.Value, out _);
+                _queueSources.TryAdd(_currentPriority.Value, new());
+            }
+
+            _currentPriority = nextPriority;
+        }
+    }
+
+    public bool TryAdd(
+        string id,
+        SurrealDbWsRequestPriority priority,
+        SurrealWsTaskCompletionSource responseTaskCompletionSource
+    )
+    {
+        var responseTasks = GetResponseTasksByPriority(priority);
+
+        if (_allResponseTaskIds.Add(id))
+        {
+            if (responseTasks.TryAdd(id, responseTaskCompletionSource!))
+            {
+                UpdateQueueSources();
+                return true;
+            }
+
+            _allResponseTaskIds.TryRemove(id);
+            return false;
+        }
+
+        return false;
+    }
+
+    public bool TryRemove(string id, out SurrealWsTaskCompletionSource responseTaskCompletionSource)
+    {
+        bool result =
+            (
+                _normalResponseTasks.TryRemove(id, out responseTaskCompletionSource!)
+                || _highResponseTasks.TryRemove(id, out responseTaskCompletionSource!)
+            ) & _allResponseTaskIds.TryRemove(id);
+
+        if (result)
+        {
+            UpdateQueueSources();
+        }
+
+        return result;
+    }
+
+    public async Task WaitUntilAsync(
+        SurrealDbWsRequestPriority priority,
+        CancellationToken cancellationToken
+    )
+    {
+        var completionTokenSource = _queueSources.GetOrAdd(
+            priority,
+            _ => new TaskCompletionSource<bool>()
+        );
+
+        await completionTokenSource.Task.ConfigureAwait(false);
+    }
+}

--- a/SurrealDb.Net/SurrealDb.Net.csproj
+++ b/SurrealDb.Net/SurrealDb.Net.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+	<PackageReference Include="ConcurrentHashSet" Version="1.3.0" />
 	<PackageReference Include="Dahomey.Cbor" Version="1.24.3" />
 	<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
 	<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What does this change do?

- Replace `requireInitialized` boolean flag with a `SurrealDbWsRequestPriority` enum as it conveys a more meaningful context
- Use of a Task queue per priority (executing High priority before Normal priority)
- Set a `30s` timeout for the WS protocol (to have a similar behavior with the HTTP protocol)
- Apply reconnection automatically on the WS protocol (and close LQs when the websocket is disconnected, with the reason `SocketClosed`)

## What is your testing strategy?

Integration tests

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)