### PR TITLE
Feat/client pooling

### DIFF
--- a/SurrealDb.Embedded.InMemory/Internals/SurrealDbEmbeddedEngineConfig.cs
+++ b/SurrealDb.Embedded.InMemory/Internals/SurrealDbEmbeddedEngineConfig.cs
@@ -1,4 +1,6 @@
-﻿namespace SurrealDb.Embedded.InMemory.Internals;
+﻿using SurrealDb.Net.Internals.Models;
+
+namespace SurrealDb.Embedded.InMemory.Internals;
 
 internal class SurrealDbEmbeddedEngineConfig
 {
@@ -15,5 +17,11 @@ internal class SurrealDbEmbeddedEngineConfig
     {
         Ns = null;
         Db = null;
+    }
+
+    public void Reset(SurrealDbClientParams @params)
+    {
+        Ns = @params.Ns;
+        Db = @params.Db;
     }
 }

--- a/SurrealDb.Embedded.InMemory/Internals/SurrealDbEngine.InMemory.cs
+++ b/SurrealDb.Embedded.InMemory/Internals/SurrealDbEngine.InMemory.cs
@@ -1,5 +1,4 @@
-﻿using System.Net;
-using System.Reactive;
+﻿using System.Reactive;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -501,10 +500,10 @@ internal class SurrealDbInMemoryEngine : ISurrealDbInMemoryEngine
         throw new NotSupportedException();
     }
 
-    public bool TryReset()
+    public Task<bool> TryResetAsync()
     {
         // 💡 No reuse needed when embedded
-        return false;
+        return Task.FromResult(false);
     }
 
     public async Task Unset(string key, CancellationToken cancellationToken)

--- a/SurrealDb.Embedded.InMemory/Internals/SurrealDbEngine.InMemory.cs
+++ b/SurrealDb.Embedded.InMemory/Internals/SurrealDbEngine.InMemory.cs
@@ -32,6 +32,10 @@ internal class SurrealDbInMemoryEngine : ISurrealDbInMemoryEngine
     private bool _isConnected;
     private bool _isInitialized;
 
+#if DEBUG
+    public string Id => _id.ToString();
+#endif
+
     static SurrealDbInMemoryEngine()
     {
         NativeMethods.create_global_runtime();
@@ -61,6 +65,11 @@ internal class SurrealDbInMemoryEngine : ISurrealDbInMemoryEngine
     public Task Authenticate(Jwt jwt, CancellationToken cancellationToken)
     {
         throw new NotSupportedException("Authentication is not enabled in embedded mode.");
+    }
+
+    public Task Clear(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
     }
 
     public void Configure(string? ns, string? db, string? username, string? password)
@@ -490,6 +499,12 @@ internal class SurrealDbInMemoryEngine : ISurrealDbInMemoryEngine
     public SurrealDbLiveQueryChannel SubscribeToLiveQuery(Guid id)
     {
         throw new NotSupportedException();
+    }
+
+    public bool TryReset()
+    {
+        // 💡 No reuse needed when embedded
+        return false;
     }
 
     public async Task Unset(string key, CancellationToken cancellationToken)

--- a/SurrealDb.Embedded.InMemory/SurrealDbMemoryClient.cs
+++ b/SurrealDb.Embedded.InMemory/SurrealDbMemoryClient.cs
@@ -53,26 +53,11 @@ public class SurrealDbMemoryClient : ISurrealDbClient
 
         _engine = new SurrealDbInMemoryEngine();
         _engine.Initialize(parameters, configureCborOptions);
-
-        if (parameters.Username is not null)
-            Configure(parameters.Ns, parameters.Db, parameters.Username, parameters.Password);
-        else
-            Configure(parameters.Ns, parameters.Db, parameters.Token);
     }
 
     public Task Authenticate(Jwt jwt, CancellationToken cancellationToken = default)
     {
         return _engine.Authenticate(jwt, cancellationToken);
-    }
-
-    public void Configure(string? ns, string? db, string? username, string? password)
-    {
-        _engine.Configure(ns, db, username, password);
-    }
-
-    public void Configure(string? ns, string? db, string? token = null)
-    {
-        _engine.Configure(ns, db, token);
     }
 
     public Task Connect(CancellationToken cancellationToken = default)

--- a/SurrealDb.Embedded.InMemory/SurrealDbMemoryClient.cs
+++ b/SurrealDb.Embedded.InMemory/SurrealDbMemoryClient.cs
@@ -110,6 +110,12 @@ public class SurrealDbMemoryClient : ISurrealDbClient
         _engine.Dispose();
     }
 
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
+    }
+
     public Task<bool> Health(CancellationToken cancellationToken = default)
     {
         return _engine.Health(cancellationToken);

--- a/SurrealDb.Net.Benchmarks.Embedded/ColdStartBench.cs
+++ b/SurrealDb.Net.Benchmarks.Embedded/ColdStartBench.cs
@@ -9,8 +9,6 @@ public class ColdStartBench : BaseEmbeddedBenchmark
     public async Task MemoryConstructor()
     {
         using var client = new SurrealDbMemoryClient(NamingPolicy);
-
-        InitializeSurrealDbClient(client, DefaultDatabaseInfo);
         await client.Connect();
     }
 }

--- a/SurrealDb.Net.Benchmarks.Embedded/CreateBench.cs
+++ b/SurrealDb.Net.Benchmarks.Embedded/CreateBench.cs
@@ -14,7 +14,10 @@ public class CreateBench : BaseEmbeddedBenchmark
     public void Setup()
     {
         _memoryClient = new SurrealDbMemoryClient(NamingPolicy);
-        InitializeSurrealDbClient(_memoryClient, DefaultDatabaseInfo);
+        _memoryClient
+            .Use(DefaultDatabaseInfo.Namespace, DefaultDatabaseInfo.Database)
+            .GetAwaiter()
+            .GetResult();
         CreatePostTable(_memoryClient, DefaultDatabaseInfo).GetAwaiter().GetResult();
     }
 

--- a/SurrealDb.Net.Benchmarks.Embedded/DeleteBench.cs
+++ b/SurrealDb.Net.Benchmarks.Embedded/DeleteBench.cs
@@ -14,7 +14,10 @@ public class DeleteBench : BaseEmbeddedBenchmark
     public void Setup()
     {
         _memoryClient = new SurrealDbMemoryClient(NamingPolicy);
-        InitializeSurrealDbClient(_memoryClient, DefaultDatabaseInfo);
+        _memoryClient
+            .Use(DefaultDatabaseInfo.Namespace, DefaultDatabaseInfo.Database)
+            .GetAwaiter()
+            .GetResult();
         SeedData(_memoryClient, DefaultDatabaseInfo, _generatedPosts).GetAwaiter().GetResult();
     }
 

--- a/SurrealDb.Net.Benchmarks.Embedded/QueryBench.cs
+++ b/SurrealDb.Net.Benchmarks.Embedded/QueryBench.cs
@@ -14,7 +14,10 @@ public class QueryBench : BaseEmbeddedBenchmark
     public void Setup()
     {
         _memoryClient = new SurrealDbMemoryClient(NamingPolicy);
-        InitializeSurrealDbClient(_memoryClient, DefaultDatabaseInfo);
+        _memoryClient
+            .Use(DefaultDatabaseInfo.Namespace, DefaultDatabaseInfo.Database)
+            .GetAwaiter()
+            .GetResult();
         SeedData(_memoryClient, DefaultDatabaseInfo, _generatedPosts).GetAwaiter().GetResult();
     }
 

--- a/SurrealDb.Net.Benchmarks.Embedded/ScenarioBench.cs
+++ b/SurrealDb.Net.Benchmarks.Embedded/ScenarioBench.cs
@@ -12,7 +12,10 @@ public class ScenarioBench : BaseEmbeddedBenchmark
     public void Setup()
     {
         _memoryClient = new SurrealDbMemoryClient(NamingPolicy);
-        InitializeSurrealDbClient(_memoryClient, DefaultDatabaseInfo);
+        _memoryClient
+            .Use(DefaultDatabaseInfo.Namespace, DefaultDatabaseInfo.Database)
+            .GetAwaiter()
+            .GetResult();
         CreateEcommerceTables(_memoryClient, DefaultDatabaseInfo).GetAwaiter().GetResult();
     }
 
@@ -26,7 +29,7 @@ public class ScenarioBench : BaseEmbeddedBenchmark
     public async Task<List<ProductAlsoPurchased>> Memory()
     {
         using var client = new SurrealDbMemoryClient(NamingPolicy);
-        InitializeSurrealDbClient(client, DefaultDatabaseInfo);
+        await client.Use(DefaultDatabaseInfo.Namespace, DefaultDatabaseInfo.Database);
 
         return await BenchmarkRuns.Scenario(_memoryClient!);
     }

--- a/SurrealDb.Net.Benchmarks.Embedded/SelectBench.cs
+++ b/SurrealDb.Net.Benchmarks.Embedded/SelectBench.cs
@@ -14,7 +14,10 @@ public class SelectBench : BaseEmbeddedBenchmark
     public void Setup()
     {
         _memoryClient = new SurrealDbMemoryClient(NamingPolicy);
-        InitializeSurrealDbClient(_memoryClient, DefaultDatabaseInfo);
+        _memoryClient
+            .Use(DefaultDatabaseInfo.Namespace, DefaultDatabaseInfo.Database)
+            .GetAwaiter()
+            .GetResult();
         SeedData(_memoryClient, DefaultDatabaseInfo, _generatedPosts).GetAwaiter().GetResult();
     }
 

--- a/SurrealDb.Net.Benchmarks.Embedded/UpsertBench.cs
+++ b/SurrealDb.Net.Benchmarks.Embedded/UpsertBench.cs
@@ -15,7 +15,10 @@ public class UpsertBench : BaseEmbeddedBenchmark
     public void Setup()
     {
         _memoryClient = new SurrealDbMemoryClient(NamingPolicy);
-        InitializeSurrealDbClient(_memoryClient, DefaultDatabaseInfo);
+        _memoryClient
+            .Use(DefaultDatabaseInfo.Namespace, DefaultDatabaseInfo.Database)
+            .GetAwaiter()
+            .GetResult();
         SeedData(_memoryClient, DefaultDatabaseInfo, _generatedPosts).GetAwaiter().GetResult();
     }
 

--- a/SurrealDb.Net.Benchmarks.Remote/ColdStartBench.cs
+++ b/SurrealDb.Net.Benchmarks.Remote/ColdStartBench.cs
@@ -40,29 +40,43 @@ public class ColdStartBench : BaseRemoteBenchmark
     [Benchmark]
     public async Task HttpConstructor()
     {
+        var options = new SurrealDbOptionsBuilder()
+            .WithEndpoint(HttpUrl)
+            .WithNamespace(_databaseInfo!.Namespace)
+            .WithDatabase(_databaseInfo!.Database)
+            .WithUsername("root")
+            .WithPassword("root")
+            .WithNamingPolicy(NamingPolicy)
+            .Build();
+
         var client = new SurrealDbClient(
-            HttpUrl,
-            NamingPolicy,
+            options,
             _serviceProvider!.GetRequiredService<IHttpClientFactory>(),
             appendJsonSerializerContexts: GetFuncJsonSerializerContexts()
         );
         _clients.Add(client);
 
-        InitializeSurrealDbClient(client, _databaseInfo!);
         await client.Connect();
     }
 
     [Benchmark]
     public async Task WsConstructor()
     {
+        var options = new SurrealDbOptionsBuilder()
+            .WithEndpoint(HttpUrl)
+            .WithNamespace(_databaseInfo!.Namespace)
+            .WithDatabase(_databaseInfo!.Database)
+            .WithUsername("root")
+            .WithPassword("root")
+            .WithNamingPolicy(NamingPolicy)
+            .Build();
+
         var client = new SurrealDbClient(
-            WsUrl,
-            NamingPolicy,
+            options,
             appendJsonSerializerContexts: GetFuncJsonSerializerContexts()
         );
         _clients.Add(client);
 
-        InitializeSurrealDbClient(client, _databaseInfo!);
         await client.Connect();
     }
 }

--- a/SurrealDb.Net.Benchmarks.Remote/CreateBench.cs
+++ b/SurrealDb.Net.Benchmarks.Remote/CreateBench.cs
@@ -37,19 +37,21 @@ public class CreateBench : BaseRemoteBenchmark
                         SurrealDbOptions
                             .Create()
                             .WithEndpoint(HttpUrl)
+                            .WithNamespace(dbInfo.Namespace)
+                            .WithDatabase(dbInfo.Database)
+                            .WithUsername("root")
+                            .WithPassword("root")
                             .WithNamingPolicy(NamingPolicy)
                             .Build(),
                         appendJsonSerializerContexts: GetFuncJsonSerializerContexts()
                     );
-                    InitializeSurrealDbClient(_surrealdbHttpClient, dbInfo);
                     await _surrealdbHttpClient.Connect();
                     break;
                 case 1:
                     _surrealdbHttpClientWithHttpClientFactory = clientGenerator.Create(
-                        $"Endpoint={HttpUrl}",
+                        $"Endpoint={HttpUrl};NS={dbInfo.Namespace};DB={dbInfo.Database};user=root;pass=root",
                         funcJsonSerializerContexts: GetFuncJsonSerializerContexts()
                     );
-                    InitializeSurrealDbClient(_surrealdbHttpClientWithHttpClientFactory, dbInfo);
                     await _surrealdbHttpClientWithHttpClientFactory.Connect();
                     break;
                 case 2:
@@ -57,11 +59,14 @@ public class CreateBench : BaseRemoteBenchmark
                         SurrealDbOptions
                             .Create()
                             .WithEndpoint(WsUrl)
+                            .WithNamespace(dbInfo.Namespace)
+                            .WithDatabase(dbInfo.Database)
+                            .WithUsername("root")
+                            .WithPassword("root")
                             .WithNamingPolicy(NamingPolicy)
                             .Build(),
                         appendJsonSerializerContexts: GetFuncJsonSerializerContexts()
                     );
-                    InitializeSurrealDbClient(_surrealdbWsTextClient, dbInfo);
                     await _surrealdbWsTextClient.Connect();
                     break;
                 case 3:
@@ -71,11 +76,14 @@ public class CreateBench : BaseRemoteBenchmark
                             SurrealDbOptions
                                 .Create()
                                 .WithEndpoint(WsUrl)
+                                .WithNamespace(dbInfo.Namespace)
+                                .WithDatabase(dbInfo.Database)
+                                .WithUsername("root")
+                                .WithPassword("root")
                                 .WithNamingPolicy(NamingPolicy)
                                 .WithSerialization(SerializationConstants.CBOR)
                                 .Build()
                         );
-                        InitializeSurrealDbClient(_surrealdbWsBinaryClient, dbInfo);
                         await _surrealdbWsBinaryClient.Connect();
                     }
                     break;

--- a/SurrealDb.Net.Benchmarks.Remote/DeleteBench.cs
+++ b/SurrealDb.Net.Benchmarks.Remote/DeleteBench.cs
@@ -33,19 +33,21 @@ public class DeleteBench : BaseRemoteBenchmark
                         SurrealDbOptions
                             .Create()
                             .WithEndpoint(HttpUrl)
+                            .WithNamespace(dbInfo.Namespace)
+                            .WithDatabase(dbInfo.Database)
+                            .WithUsername("root")
+                            .WithPassword("root")
                             .WithNamingPolicy(NamingPolicy)
                             .Build(),
                         appendJsonSerializerContexts: GetFuncJsonSerializerContexts()
                     );
-                    InitializeSurrealDbClient(_surrealdbHttpClient, dbInfo);
                     await _surrealdbHttpClient.Connect();
                     break;
                 case 1:
                     _surrealdbHttpClientWithHttpClientFactory = clientGenerator.Create(
-                        $"Endpoint={HttpUrl}",
+                        $"Endpoint={HttpUrl};NS={dbInfo.Namespace};DB={dbInfo.Database};user=root;pass=root",
                         funcJsonSerializerContexts: GetFuncJsonSerializerContexts()
                     );
-                    InitializeSurrealDbClient(_surrealdbHttpClientWithHttpClientFactory, dbInfo);
                     await _surrealdbHttpClientWithHttpClientFactory.Connect();
                     break;
                 case 2:
@@ -53,11 +55,14 @@ public class DeleteBench : BaseRemoteBenchmark
                         SurrealDbOptions
                             .Create()
                             .WithEndpoint(WsUrl)
+                            .WithNamespace(dbInfo.Namespace)
+                            .WithDatabase(dbInfo.Database)
+                            .WithUsername("root")
+                            .WithPassword("root")
                             .WithNamingPolicy(NamingPolicy)
                             .Build(),
                         appendJsonSerializerContexts: GetFuncJsonSerializerContexts()
                     );
-                    InitializeSurrealDbClient(_surrealdbWsTextClient, dbInfo);
                     await _surrealdbWsTextClient.Connect();
                     break;
                 case 3:
@@ -67,11 +72,14 @@ public class DeleteBench : BaseRemoteBenchmark
                             SurrealDbOptions
                                 .Create()
                                 .WithEndpoint(WsUrl)
+                                .WithNamespace(dbInfo.Namespace)
+                                .WithDatabase(dbInfo.Database)
+                                .WithUsername("root")
+                                .WithPassword("root")
                                 .WithNamingPolicy(NamingPolicy)
                                 .WithSerialization(SerializationConstants.CBOR)
                                 .Build()
                         );
-                        InitializeSurrealDbClient(_surrealdbWsBinaryClient, dbInfo);
                         await _surrealdbWsBinaryClient.Connect();
                     }
                     break;

--- a/SurrealDb.Net.Benchmarks.Remote/QueryBench.cs
+++ b/SurrealDb.Net.Benchmarks.Remote/QueryBench.cs
@@ -33,19 +33,21 @@ public class QueryBench : BaseRemoteBenchmark
                         SurrealDbOptions
                             .Create()
                             .WithEndpoint(HttpUrl)
+                            .WithNamespace(dbInfo.Namespace)
+                            .WithDatabase(dbInfo.Database)
+                            .WithUsername("root")
+                            .WithPassword("root")
                             .WithNamingPolicy(NamingPolicy)
                             .Build(),
                         appendJsonSerializerContexts: GetFuncJsonSerializerContexts()
                     );
-                    InitializeSurrealDbClient(_surrealdbHttpClient, dbInfo);
                     await _surrealdbHttpClient.Connect();
                     break;
                 case 1:
                     _surrealdbHttpClientWithHttpClientFactory = clientGenerator.Create(
-                        $"Endpoint={HttpUrl}",
+                        $"Endpoint={HttpUrl};NS={dbInfo.Namespace};DB={dbInfo.Database};user=root;pass=root",
                         funcJsonSerializerContexts: GetFuncJsonSerializerContexts()
                     );
-                    InitializeSurrealDbClient(_surrealdbHttpClientWithHttpClientFactory, dbInfo);
                     await _surrealdbHttpClientWithHttpClientFactory.Connect();
                     break;
                 case 2:
@@ -53,11 +55,14 @@ public class QueryBench : BaseRemoteBenchmark
                         SurrealDbOptions
                             .Create()
                             .WithEndpoint(WsUrl)
+                            .WithNamespace(dbInfo.Namespace)
+                            .WithDatabase(dbInfo.Database)
+                            .WithUsername("root")
+                            .WithPassword("root")
                             .WithNamingPolicy(NamingPolicy)
                             .Build(),
                         appendJsonSerializerContexts: GetFuncJsonSerializerContexts()
                     );
-                    InitializeSurrealDbClient(_surrealdbWsTextClient, dbInfo);
                     await _surrealdbWsTextClient.Connect();
                     break;
                 case 3:
@@ -67,11 +72,14 @@ public class QueryBench : BaseRemoteBenchmark
                             SurrealDbOptions
                                 .Create()
                                 .WithEndpoint(WsUrl)
+                                .WithNamespace(dbInfo.Namespace)
+                                .WithDatabase(dbInfo.Database)
+                                .WithUsername("root")
+                                .WithPassword("root")
                                 .WithNamingPolicy(NamingPolicy)
                                 .WithSerialization(SerializationConstants.CBOR)
                                 .Build()
                         );
-                        InitializeSurrealDbClient(_surrealdbWsBinaryClient, dbInfo);
                         await _surrealdbWsBinaryClient.Connect();
                     }
                     break;

--- a/SurrealDb.Net.Benchmarks.Remote/ScenarioBench.cs
+++ b/SurrealDb.Net.Benchmarks.Remote/ScenarioBench.cs
@@ -34,19 +34,21 @@ public class ScenarioBench : BaseRemoteBenchmark
                         SurrealDbOptions
                             .Create()
                             .WithEndpoint(HttpUrl)
+                            .WithNamespace(dbInfo.Namespace)
+                            .WithDatabase(dbInfo.Database)
+                            .WithUsername("root")
+                            .WithPassword("root")
                             .WithNamingPolicy(NamingPolicy)
                             .Build(),
                         appendJsonSerializerContexts: GetFuncJsonSerializerContexts()
                     );
-                    InitializeSurrealDbClient(_surrealdbHttpClient, dbInfo);
                     await _surrealdbHttpClient.Connect();
                     break;
                 case 1:
                     _surrealdbHttpClientWithHttpClientFactory = clientGenerator.Create(
-                        $"Endpoint={HttpUrl}",
+                        $"Endpoint={HttpUrl};NS={dbInfo.Namespace};DB={dbInfo.Database};user=root;pass=root",
                         funcJsonSerializerContexts: GetFuncJsonSerializerContexts()
                     );
-                    InitializeSurrealDbClient(_surrealdbHttpClientWithHttpClientFactory, dbInfo);
                     await _surrealdbHttpClientWithHttpClientFactory.Connect();
                     break;
                 case 2:
@@ -54,11 +56,14 @@ public class ScenarioBench : BaseRemoteBenchmark
                         SurrealDbOptions
                             .Create()
                             .WithEndpoint(WsUrl)
+                            .WithNamespace(dbInfo.Namespace)
+                            .WithDatabase(dbInfo.Database)
+                            .WithUsername("root")
+                            .WithPassword("root")
                             .WithNamingPolicy(NamingPolicy)
                             .Build(),
                         appendJsonSerializerContexts: GetFuncJsonSerializerContexts()
                     );
-                    InitializeSurrealDbClient(_surrealdbWsTextClient, dbInfo);
                     await _surrealdbWsTextClient.Connect();
                     break;
                 case 3:
@@ -68,11 +73,14 @@ public class ScenarioBench : BaseRemoteBenchmark
                             SurrealDbOptions
                                 .Create()
                                 .WithEndpoint(WsUrl)
+                                .WithNamespace(dbInfo.Namespace)
+                                .WithDatabase(dbInfo.Database)
+                                .WithUsername("root")
+                                .WithPassword("root")
                                 .WithNamingPolicy(NamingPolicy)
                                 .WithSerialization(SerializationConstants.CBOR)
                                 .Build()
                         );
-                        InitializeSurrealDbClient(_surrealdbWsBinaryClient, dbInfo);
                         await _surrealdbWsBinaryClient.Connect();
                     }
                     break;

--- a/SurrealDb.Net.Benchmarks.Remote/SelectBench.cs
+++ b/SurrealDb.Net.Benchmarks.Remote/SelectBench.cs
@@ -33,19 +33,21 @@ public class SelectBench : BaseRemoteBenchmark
                         SurrealDbOptions
                             .Create()
                             .WithEndpoint(HttpUrl)
+                            .WithNamespace(dbInfo.Namespace)
+                            .WithDatabase(dbInfo.Database)
+                            .WithUsername("root")
+                            .WithPassword("root")
                             .WithNamingPolicy(NamingPolicy)
                             .Build(),
                         appendJsonSerializerContexts: GetFuncJsonSerializerContexts()
                     );
-                    InitializeSurrealDbClient(_surrealdbHttpClient, dbInfo);
                     await _surrealdbHttpClient.Connect();
                     break;
                 case 1:
                     _surrealdbHttpClientWithHttpClientFactory = clientGenerator.Create(
-                        $"Endpoint={HttpUrl}",
+                        $"Endpoint={HttpUrl};NS={dbInfo.Namespace};DB={dbInfo.Database};user=root;pass=root",
                         funcJsonSerializerContexts: GetFuncJsonSerializerContexts()
                     );
-                    InitializeSurrealDbClient(_surrealdbHttpClientWithHttpClientFactory, dbInfo);
                     await _surrealdbHttpClientWithHttpClientFactory.Connect();
                     break;
                 case 2:
@@ -53,11 +55,14 @@ public class SelectBench : BaseRemoteBenchmark
                         SurrealDbOptions
                             .Create()
                             .WithEndpoint(WsUrl)
+                            .WithNamespace(dbInfo.Namespace)
+                            .WithDatabase(dbInfo.Database)
+                            .WithUsername("root")
+                            .WithPassword("root")
                             .WithNamingPolicy(NamingPolicy)
                             .Build(),
                         appendJsonSerializerContexts: GetFuncJsonSerializerContexts()
                     );
-                    InitializeSurrealDbClient(_surrealdbWsTextClient, dbInfo);
                     await _surrealdbWsTextClient.Connect();
                     break;
                 case 3:
@@ -67,11 +72,14 @@ public class SelectBench : BaseRemoteBenchmark
                             SurrealDbOptions
                                 .Create()
                                 .WithEndpoint(WsUrl)
+                                .WithNamespace(dbInfo.Namespace)
+                                .WithDatabase(dbInfo.Database)
+                                .WithUsername("root")
+                                .WithPassword("root")
                                 .WithNamingPolicy(NamingPolicy)
                                 .WithSerialization(SerializationConstants.CBOR)
                                 .Build()
                         );
-                        InitializeSurrealDbClient(_surrealdbWsBinaryClient, dbInfo);
                         await _surrealdbWsBinaryClient.Connect();
                     }
                     break;

--- a/SurrealDb.Net.Benchmarks.Remote/UpsertBench.cs
+++ b/SurrealDb.Net.Benchmarks.Remote/UpsertBench.cs
@@ -35,19 +35,21 @@ public class UpsertBench : BaseRemoteBenchmark
                         SurrealDbOptions
                             .Create()
                             .WithEndpoint(HttpUrl)
+                            .WithNamespace(dbInfo.Namespace)
+                            .WithDatabase(dbInfo.Database)
+                            .WithUsername("root")
+                            .WithPassword("root")
                             .WithNamingPolicy(NamingPolicy)
                             .Build(),
                         appendJsonSerializerContexts: GetFuncJsonSerializerContexts()
                     );
-                    InitializeSurrealDbClient(_surrealdbHttpClient, dbInfo);
                     await _surrealdbHttpClient.Connect();
                     break;
                 case 1:
                     _surrealdbHttpClientWithHttpClientFactory = clientGenerator.Create(
-                        $"Endpoint={HttpUrl}",
+                        $"Endpoint={HttpUrl};NS={dbInfo.Namespace};DB={dbInfo.Database};user=root;pass=root",
                         funcJsonSerializerContexts: GetFuncJsonSerializerContexts()
                     );
-                    InitializeSurrealDbClient(_surrealdbHttpClientWithHttpClientFactory, dbInfo);
                     await _surrealdbHttpClientWithHttpClientFactory.Connect();
                     break;
                 case 2:
@@ -55,11 +57,14 @@ public class UpsertBench : BaseRemoteBenchmark
                         SurrealDbOptions
                             .Create()
                             .WithEndpoint(WsUrl)
+                            .WithNamespace(dbInfo.Namespace)
+                            .WithDatabase(dbInfo.Database)
+                            .WithUsername("root")
+                            .WithPassword("root")
                             .WithNamingPolicy(NamingPolicy)
                             .Build(),
                         appendJsonSerializerContexts: GetFuncJsonSerializerContexts()
                     );
-                    InitializeSurrealDbClient(_surrealdbWsTextClient, dbInfo);
                     await _surrealdbWsTextClient.Connect();
                     break;
                 case 3:
@@ -69,11 +74,14 @@ public class UpsertBench : BaseRemoteBenchmark
                             SurrealDbOptions
                                 .Create()
                                 .WithEndpoint(WsUrl)
+                                .WithNamespace(dbInfo.Namespace)
+                                .WithDatabase(dbInfo.Database)
+                                .WithUsername("root")
+                                .WithPassword("root")
                                 .WithNamingPolicy(NamingPolicy)
                                 .WithSerialization(SerializationConstants.CBOR)
                                 .Build()
                         );
-                        InitializeSurrealDbClient(_surrealdbWsBinaryClient, dbInfo);
                         await _surrealdbWsBinaryClient.Connect();
                     }
                     break;

--- a/SurrealDb.Net.Benchmarks/BaseBenchmark.cs
+++ b/SurrealDb.Net.Benchmarks/BaseBenchmark.cs
@@ -6,23 +6,14 @@ public class BaseBenchmark
 {
     protected string NamingPolicy { get; } = "SnakeCase";
 
-    protected void InitializeSurrealDbClient(ISurrealDbClient client, DatabaseInfo databaseInfo)
-    {
-        client.Configure(databaseInfo.Namespace, databaseInfo.Database, "root", "root");
-    }
-
     protected async Task CreatePostTable(ISurrealDbClient client, DatabaseInfo databaseInfo)
     {
-        InitializeSurrealDbClient(client, databaseInfo);
-
         string query = GetPostQueryContent();
         await client.RawQuery(query);
     }
 
     protected async Task CreateEcommerceTables(ISurrealDbClient client, DatabaseInfo databaseInfo)
     {
-        InitializeSurrealDbClient(client, databaseInfo);
-
         string query = GetEcommerceQueryContent();
         await client.RawQuery(query);
     }
@@ -33,8 +24,6 @@ public class BaseBenchmark
         IEnumerable<GeneratedPost> posts
     )
     {
-        InitializeSurrealDbClient(client, databaseInfo);
-
         var tasks = new List<Task>();
 
         foreach (var post in posts)
@@ -51,8 +40,6 @@ public class BaseBenchmark
 
     protected async Task<Post> GetFirstPost(ISurrealDbClient client, DatabaseInfo databaseInfo)
     {
-        InitializeSurrealDbClient(client, databaseInfo);
-
         var posts = await client.Select<Post>("post");
         return posts.First();
     }

--- a/SurrealDb.Net.Tests.Fixtures/SurrealDb.Net.Tests.Fixtures.csproj
+++ b/SurrealDb.Net.Tests.Fixtures/SurrealDb.Net.Tests.Fixtures.csproj
@@ -9,6 +9,18 @@
   </ItemGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>SurrealDb.Net.Tests</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>SurrealDb.Net.LiveQuery.Tests</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>SurrealDb.Net.Benchmarks.Remote</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\SurrealDb.Embedded.InMemory\SurrealDb.Embedded.InMemory.csproj" />
     <ProjectReference Include="..\SurrealDb.Net\SurrealDb.Net.csproj" />
   </ItemGroup>

--- a/SurrealDb.Net.Tests/ConnectTests.cs
+++ b/SurrealDb.Net.Tests/ConnectTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 using Dahomey.Cbor.Attributes;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace SurrealDb.Net.Tests;
 
@@ -47,8 +48,14 @@ public class ConnectTests
             using var surrealDbClientGenerator = new SurrealDbClientGenerator();
             dbInfo = surrealDbClientGenerator.GenerateDatabaseInfo();
 
-            using var client = new SurrealDbClient("ws://127.0.0.1:8000/rpc");
-            client.Configure(dbInfo.Namespace, dbInfo.Database);
+            using var client = new SurrealDbClient(
+                new SurrealDbOptions
+                {
+                    Endpoint = "ws://127.0.0.1:8000/rpc",
+                    Namespace = dbInfo.Namespace,
+                    Database = dbInfo.Database
+                }
+            );
 
             await client.Connect();
 

--- a/SurrealDb.Net.Tests/ObjectPoolTests.cs
+++ b/SurrealDb.Net.Tests/ObjectPoolTests.cs
@@ -1,0 +1,203 @@
+﻿using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using SurrealDb.Net.Internals;
+
+namespace SurrealDb.Net.Tests;
+
+public class ObjectPoolTests
+{
+    [Theory]
+    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=JSON")]
+    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=CBOR")]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=JSON")]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=CBOR")]
+    public async Task ShouldCreateTwoDistinctEngines(string connectionString)
+    {
+        ISurrealDbEngine? engine1 = null;
+        ISurrealDbEngine? engine2 = null;
+
+        Func<Task> func = async () =>
+        {
+            await using var surrealDbClientGenerator = new SurrealDbClientGenerator().Configure(
+                connectionString,
+                ServiceLifetime.Scoped
+            );
+            var dbInfo = surrealDbClientGenerator.GenerateDatabaseInfo();
+
+            using var scope1 = surrealDbClientGenerator.CreateScope()!;
+            using var scope2 = surrealDbClientGenerator.CreateScope()!;
+
+            var client1 = scope1.ServiceProvider.GetRequiredService<SurrealDbClient>();
+            await client1.Use(dbInfo.Namespace, dbInfo.Database);
+            engine1 = client1.Engine;
+
+            var client2 = scope2.ServiceProvider.GetRequiredService<SurrealDbClient>();
+            await client2.Use(dbInfo.Namespace, dbInfo.Database);
+            engine2 = client2.Engine;
+
+            client1.Dispose();
+            client2.Dispose();
+        };
+
+        await func.Should().NotThrowAsync();
+
+        engine1.Should().NotBeNull();
+        engine2.Should().NotBeNull();
+        engine1.Should().NotBe(engine2);
+    }
+
+    [Theory]
+    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=JSON")]
+    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=CBOR")]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=JSON")]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=CBOR")]
+    public async Task ShouldReuseTheSameEngineAcrossClients(string connectionString)
+    {
+        ISurrealDbEngine? engine1 = null;
+        ISurrealDbEngine? engine2 = null;
+
+        Func<Task> func = async () =>
+        {
+            await using var surrealDbClientGenerator = new SurrealDbClientGenerator().Configure(
+                connectionString,
+                ServiceLifetime.Scoped
+            );
+            var dbInfo = surrealDbClientGenerator.GenerateDatabaseInfo();
+
+            using var scope1 = surrealDbClientGenerator.CreateScope()!;
+
+            var client1 = scope1.ServiceProvider.GetRequiredService<SurrealDbClient>();
+            await client1.SignIn(new RootAuth { Username = "root", Password = "root" });
+            await client1.Use(dbInfo.Namespace, dbInfo.Database);
+            engine1 = client1.Engine;
+
+            client1.Dispose();
+
+            using var scope2 = surrealDbClientGenerator.CreateScope()!;
+
+            var client2 = scope2.ServiceProvider.GetRequiredService<SurrealDbClient>();
+            await client2.SignIn(new RootAuth { Username = "root", Password = "root" });
+            await client2.Use(dbInfo.Namespace, dbInfo.Database);
+            engine2 = client2.Engine;
+
+            client2.Dispose();
+        };
+
+        await func.Should().NotThrowAsync();
+
+        engine1.Should().NotBeNull();
+        engine2.Should().NotBeNull();
+        engine1.Should().Be(engine2);
+    }
+
+    [Theory]
+    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=JSON")]
+    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=CBOR")]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=JSON")]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=CBOR")]
+    public async Task ShouldResetAuthWhenClientIsReused(string connectionString)
+    {
+        User? userSession1 = null;
+        User? userSession2 = null;
+
+        Func<Task> func = async () =>
+        {
+            await using var surrealDbClientGenerator = new SurrealDbClientGenerator().Configure(
+                connectionString,
+                ServiceLifetime.Scoped
+            );
+            var dbInfo = surrealDbClientGenerator.GenerateDatabaseInfo();
+
+            using var scope1 = surrealDbClientGenerator.CreateScope()!;
+
+            var client1 = scope1.ServiceProvider.GetRequiredService<SurrealDbClient>();
+            await client1.SignIn(new RootAuth { Username = "root", Password = "root" });
+            await client1.Use(dbInfo.Namespace, dbInfo.Database);
+
+            {
+                string filePath = Path.Combine(
+                    AppDomain.CurrentDomain.BaseDirectory,
+                    "Schemas/user.surql"
+                );
+                string fileContent = File.ReadAllText(filePath, Encoding.UTF8);
+
+                string query = fileContent;
+                await client1.RawQuery(query);
+            }
+
+            {
+                var authParams = new AuthParams
+                {
+                    Namespace = dbInfo.Namespace,
+                    Database = dbInfo.Database,
+                    Scope = "user_scope",
+                    Username = "johndoe",
+                    Email = "john.doe@example.com",
+                    Password = "password123"
+                };
+
+                var jwt = await client1.SignUp(authParams);
+                await client1.Authenticate(jwt);
+            }
+
+            userSession1 = await client1.Info<User>();
+
+            client1.Dispose();
+
+            using var scope2 = surrealDbClientGenerator.CreateScope()!;
+
+            using var client2 = scope2.ServiceProvider.GetRequiredService<SurrealDbClient>();
+            await client2.Use(dbInfo.Namespace, dbInfo.Database);
+
+            userSession2 = await client2.Info<User>();
+        };
+
+        await func.Should().NotThrowAsync();
+
+        userSession1.Should().NotBeNull();
+        userSession2.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=JSON;NS=alpha;DB=alpha")]
+    [InlineData("Endpoint=http://127.0.0.1:8000;Serialization=CBOR;NS=alpha;DB=alpha")]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=JSON;NS=alpha;DB=alpha")]
+    [InlineData("Endpoint=ws://127.0.0.1:8000/rpc;Serialization=CBOR;NS=alpha;DB=alpha")]
+    public async Task ShouldResetDbNs(string connectionString)
+    {
+        DatabaseInfo? dbInfo = null;
+        SessionInfo? result = null;
+
+        Func<Task> func = async () =>
+        {
+            await using var surrealDbClientGenerator = new SurrealDbClientGenerator().Configure(
+                connectionString,
+                ServiceLifetime.Scoped
+            );
+            dbInfo = surrealDbClientGenerator.GenerateDatabaseInfo();
+
+            using var scope1 = surrealDbClientGenerator.CreateScope()!;
+
+            var client1 = scope1.ServiceProvider.GetRequiredService<SurrealDbClient>();
+            await client1.SignIn(new RootAuth { Username = "root", Password = "root" });
+            await client1.Use(dbInfo.Namespace, dbInfo.Database);
+
+            using var scope2 = surrealDbClientGenerator.CreateScope()!;
+
+            var client2 = scope2.ServiceProvider.GetRequiredService<SurrealDbClient>();
+            await client2.SignIn(new RootAuth { Username = "root", Password = "root" });
+
+            var response = await client2.Query($"SELECT * FROM $session;");
+
+            var list = response.GetValue<List<SessionInfo>>(0)!;
+            result = list[0];
+        };
+
+        await func.Should().NotThrowAsync();
+
+        result.Should().NotBeNull();
+
+        result!.Namespace.Should().Be("alpha");
+        result!.Database.Should().Be("alpha");
+    }
+}

--- a/SurrealDb.Net.Tests/ObjectPoolTests.cs
+++ b/SurrealDb.Net.Tests/ObjectPoolTests.cs
@@ -35,8 +35,8 @@ public class ObjectPoolTests
             await client2.Use(dbInfo.Namespace, dbInfo.Database);
             engine2 = client2.Engine;
 
-            client1.Dispose();
-            client2.Dispose();
+            await client1.DisposeAsync();
+            await client2.DisposeAsync();
         };
 
         await func.Should().NotThrowAsync();
@@ -71,7 +71,7 @@ public class ObjectPoolTests
             await client1.Use(dbInfo.Namespace, dbInfo.Database);
             engine1 = client1.Engine;
 
-            client1.Dispose();
+            await client1.DisposeAsync();
 
             using var scope2 = surrealDbClientGenerator.CreateScope()!;
 
@@ -80,7 +80,7 @@ public class ObjectPoolTests
             await client2.Use(dbInfo.Namespace, dbInfo.Database);
             engine2 = client2.Engine;
 
-            client2.Dispose();
+            await client2.DisposeAsync();
         };
 
         await func.Should().NotThrowAsync();
@@ -142,11 +142,11 @@ public class ObjectPoolTests
 
             userSession1 = await client1.Info<User>();
 
-            client1.Dispose();
+            await client1.DisposeAsync();
 
             using var scope2 = surrealDbClientGenerator.CreateScope()!;
 
-            using var client2 = scope2.ServiceProvider.GetRequiredService<SurrealDbClient>();
+            await using var client2 = scope2.ServiceProvider.GetRequiredService<SurrealDbClient>();
             await client2.Use(dbInfo.Namespace, dbInfo.Database);
 
             userSession2 = await client2.Info<User>();
@@ -178,13 +178,13 @@ public class ObjectPoolTests
 
             using var scope1 = surrealDbClientGenerator.CreateScope()!;
 
-            var client1 = scope1.ServiceProvider.GetRequiredService<SurrealDbClient>();
+            await using var client1 = scope1.ServiceProvider.GetRequiredService<SurrealDbClient>();
             await client1.SignIn(new RootAuth { Username = "root", Password = "root" });
             await client1.Use(dbInfo.Namespace, dbInfo.Database);
 
             using var scope2 = surrealDbClientGenerator.CreateScope()!;
 
-            var client2 = scope2.ServiceProvider.GetRequiredService<SurrealDbClient>();
+            await using var client2 = scope2.ServiceProvider.GetRequiredService<SurrealDbClient>();
             await client2.SignIn(new RootAuth { Username = "root", Password = "root" });
 
             var response = await client2.Query($"SELECT * FROM $session;");

--- a/SurrealDb.Net/Internals/Http/SurrealDbHttpEngineConfig.cs
+++ b/SurrealDb.Net/Internals/Http/SurrealDbHttpEngineConfig.cs
@@ -12,6 +12,11 @@ internal class SurrealDbHttpEngineConfig
     private readonly Dictionary<string, object> _parameters = new();
     public IReadOnlyDictionary<string, object> Parameters => _parameters;
 
+    public SurrealDbHttpEngineConfig(SurrealDbClientParams @params)
+    {
+        Reset(@params);
+    }
+
     public void Use(string ns, string? db)
     {
         Ns = ns;

--- a/SurrealDb.Net/Internals/Http/SurrealDbHttpEngineConfig.cs
+++ b/SurrealDb.Net/Internals/Http/SurrealDbHttpEngineConfig.cs
@@ -1,4 +1,5 @@
-using SurrealDb.Net.Internals.Auth;
+﻿using SurrealDb.Net.Internals.Auth;
+using SurrealDb.Net.Internals.Models;
 
 namespace SurrealDb.Net.Internals.Http;
 
@@ -40,5 +41,25 @@ internal class SurrealDbHttpEngineConfig
     public void RemoveParam(string key)
     {
         _parameters.Remove(key);
+    }
+
+    public void Reset(SurrealDbClientParams @params)
+    {
+        _parameters.Clear();
+        Ns = @params.Ns;
+        Db = @params.Db;
+
+        if (@params.Username is not null)
+        {
+            SetBasicAuth(@params.Username, @params.Password);
+        }
+        else if (@params.Token is not null)
+        {
+            SetBearerAuth(@params.Token);
+        }
+        else
+        {
+            ResetAuth();
+        }
     }
 }

--- a/SurrealDb.Net/Internals/ObjectPool/AsyncPooledObjectPolicy.cs
+++ b/SurrealDb.Net/Internals/ObjectPool/AsyncPooledObjectPolicy.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Extensions.ObjectPool;
+
+namespace SurrealDb.Net.Internals.ObjectPool;
+
+internal class AsyncPooledObjectPolicy<T> : DefaultPooledObjectPolicy<T>
+    where T : class, new()
+{
+    public Task<bool> ReturnAsync(T obj)
+    {
+        if (obj is IAsyncResettable resettable)
+        {
+            return resettable.TryResetAsync();
+        }
+
+        return Task.FromResult(true);
+    }
+}

--- a/SurrealDb.Net/Internals/ObjectPool/DefaultObjectPool.cs
+++ b/SurrealDb.Net/Internals/ObjectPool/DefaultObjectPool.cs
@@ -1,0 +1,96 @@
+﻿using System.Collections.Concurrent;
+using Microsoft.Extensions.ObjectPool;
+
+namespace SurrealDb.Net.Internals.ObjectPool;
+
+// 💡 Taken from https://github.com/dotnet/aspnetcore/blob/main/src/ObjectPool/src/DefaultObjectPool.cs
+
+/// <summary>
+/// Default implementation of <see cref="ObjectPool{T}"/>.
+/// </summary>
+/// <typeparam name="T">The type to pool objects for.</typeparam>
+/// <remarks>This implementation keeps a cache of retained objects. This means that if objects are returned when the pool has already reached "maximumRetained" objects they will be available to be Garbage Collected.</remarks>
+internal class DefaultObjectPool<T> : ObjectPool<T>
+    where T : class
+{
+    private readonly Func<T> _createFunc;
+    private readonly Func<T, bool> _returnFunc;
+    private protected readonly int _maxCapacity;
+    private protected int _numItems;
+
+    private protected readonly ConcurrentQueue<T> _items = new();
+    private protected T? _fastItem;
+
+    /// <summary>
+    /// Creates an instance of <see cref="DefaultObjectPool{T}"/>.
+    /// </summary>
+    /// <param name="policy">The pooling policy to use.</param>
+    public DefaultObjectPool(IPooledObjectPolicy<T> policy)
+        : this(policy, Environment.ProcessorCount * 2) { }
+
+    /// <summary>
+    /// Creates an instance of <see cref="DefaultObjectPool{T}"/>.
+    /// </summary>
+    /// <param name="policy">The pooling policy to use.</param>
+    /// <param name="maximumRetained">The maximum number of objects to retain in the pool.</param>
+    public DefaultObjectPool(IPooledObjectPolicy<T> policy, int maximumRetained)
+    {
+        // cache the target interface methods, to avoid interface lookup overhead
+        _createFunc = policy.Create;
+        _returnFunc = policy.Return;
+        _maxCapacity = maximumRetained - 1; // -1 to account for _fastItem
+    }
+
+    /// <inheritdoc />
+    public override T Get()
+    {
+        var item = _fastItem;
+        if (item == null || Interlocked.CompareExchange(ref _fastItem, null, item) != item)
+        {
+            if (_items.TryDequeue(out item))
+            {
+                Interlocked.Decrement(ref _numItems);
+                return item;
+            }
+
+            // no object available, so go get a brand new one
+            return _createFunc();
+        }
+
+        return item;
+    }
+
+    /// <inheritdoc />
+    public override void Return(T obj)
+    {
+        ReturnCore(obj);
+    }
+
+    /// <summary>
+    /// Returns an object to the pool.
+    /// </summary>
+    /// <returns>true if the object was returned to the pool</returns>
+    private protected bool ReturnCore(T obj)
+    {
+        if (!_returnFunc(obj))
+        {
+            // policy says to drop this object
+            return false;
+        }
+
+        if (_fastItem != null || Interlocked.CompareExchange(ref _fastItem, obj, null) != null)
+        {
+            if (Interlocked.Increment(ref _numItems) <= _maxCapacity)
+            {
+                _items.Enqueue(obj);
+                return true;
+            }
+
+            // no room, clean up the count and drop the object on the floor
+            Interlocked.Decrement(ref _numItems);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/SurrealDb.Net/Internals/ObjectPool/IAsyncResettable.cs
+++ b/SurrealDb.Net/Internals/ObjectPool/IAsyncResettable.cs
@@ -1,0 +1,6 @@
+﻿namespace SurrealDb.Net.Internals.ObjectPool;
+
+public interface IAsyncResettable
+{
+    Task<bool> TryResetAsync();
+}

--- a/SurrealDb.Net/Internals/ObjectPool/SurrealDbClientPool.cs
+++ b/SurrealDb.Net/Internals/ObjectPool/SurrealDbClientPool.cs
@@ -1,0 +1,97 @@
+﻿namespace SurrealDb.Net.Internals.ObjectPool;
+
+internal class SurrealDbClientPool : DefaultObjectPool<SurrealDbClientPoolContainer>, IDisposable
+{
+    private volatile bool _isDisposed;
+    private protected AsyncPooledObjectPolicy<SurrealDbClientPoolContainer> _policy;
+
+    public SurrealDbClientPool(AsyncPooledObjectPolicy<SurrealDbClientPoolContainer> policy)
+        : base(policy)
+    {
+        _policy = policy;
+    }
+
+    public SurrealDbClientPool(
+        AsyncPooledObjectPolicy<SurrealDbClientPoolContainer> policy,
+        int maximumRetained
+    )
+        : base(policy, maximumRetained)
+    {
+        _policy = policy;
+    }
+
+    public override SurrealDbClientPoolContainer Get()
+    {
+        if (_isDisposed)
+        {
+            ThrowObjectDisposedException();
+        }
+
+        return base.Get();
+
+        void ThrowObjectDisposedException()
+        {
+            throw new ObjectDisposedException(GetType().Name);
+        }
+    }
+
+    public override void Return(SurrealDbClientPoolContainer obj)
+    {
+        throw new NotImplementedException(
+            "This method should not be called. Use ReturnAsync instead."
+        );
+    }
+
+    public async Task ReturnAsync(SurrealDbClientPoolContainer obj)
+    {
+        if (_isDisposed || !(await ReturnAsyncCore(obj).ConfigureAwait(false)))
+        {
+            DisposeItem(obj);
+        }
+    }
+
+    private async Task<bool> ReturnAsyncCore(SurrealDbClientPoolContainer obj)
+    {
+        if (!(await _policy.ReturnAsync(obj).ConfigureAwait(false)))
+        {
+            // policy says to drop this object
+            return false;
+        }
+
+        if (_fastItem != null || Interlocked.CompareExchange(ref _fastItem, obj, null) != null)
+        {
+            if (Interlocked.Increment(ref _numItems) <= _maxCapacity)
+            {
+                _items.Enqueue(obj);
+                return true;
+            }
+
+            // no room, clean up the count and drop the object on the floor
+            Interlocked.Decrement(ref _numItems);
+            return false;
+        }
+
+        return true;
+    }
+
+    public void Dispose()
+    {
+        _isDisposed = true;
+
+        DisposeItem(_fastItem);
+        _fastItem = null;
+
+        while (_items.TryDequeue(out var item))
+        {
+            DisposeItem(item);
+        }
+    }
+
+    private static void DisposeItem(SurrealDbClientPoolContainer? item)
+    {
+        if (item is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+    }
+}

--- a/SurrealDb.Net/Internals/ObjectPool/SurrealDbClientPoolContainer.cs
+++ b/SurrealDb.Net/Internals/ObjectPool/SurrealDbClientPoolContainer.cs
@@ -1,24 +1,21 @@
-﻿using Microsoft.Extensions.ObjectPool;
+﻿namespace SurrealDb.Net.Internals.ObjectPool;
 
-namespace SurrealDb.Net.Internals.ObjectPool;
-
-internal class SurrealDbClientPoolContainer : IResettable
+internal class SurrealDbClientPoolContainer : IDisposable, IAsyncResettable
 {
     public ISurrealDbEngine? ClientEngine { get; set; }
 
-    public bool TryReset()
+    public Task<bool> TryResetAsync()
     {
         if (ClientEngine is null)
         {
-            return false;
+            return Task.FromResult(false);
         }
 
-        bool isReset = ClientEngine.TryReset();
-        if (!isReset)
-        {
-            ClientEngine.Dispose();
-        }
+        return ClientEngine.TryResetAsync();
+    }
 
-        return isReset;
+    public void Dispose()
+    {
+        ClientEngine?.Dispose();
     }
 }

--- a/SurrealDb.Net/Internals/ObjectPool/SurrealDbClientPoolContainer.cs
+++ b/SurrealDb.Net/Internals/ObjectPool/SurrealDbClientPoolContainer.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Extensions.ObjectPool;
+
+namespace SurrealDb.Net.Internals.ObjectPool;
+
+internal class SurrealDbClientPoolContainer : IResettable
+{
+    public ISurrealDbEngine? ClientEngine { get; set; }
+
+    public bool TryReset()
+    {
+        if (ClientEngine is null)
+        {
+            return false;
+        }
+
+        bool isReset = ClientEngine.TryReset();
+        if (!isReset)
+        {
+            ClientEngine.Dispose();
+        }
+
+        return isReset;
+    }
+}

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Http.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Http.cs
@@ -649,11 +649,11 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
         throw new NotSupportedException();
     }
 
-    public bool TryReset()
+    public async Task<bool> TryResetAsync()
     {
         try
         {
-            Clear(default).ConfigureAwait(false).GetAwaiter().GetResult();
+            await Clear(default).ConfigureAwait(false);
             _config.Reset(_parameters);
             return true;
         }

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Http.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Http.cs
@@ -61,7 +61,7 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
     private readonly Action<CborOptions>? _configureCborOptions;
     private readonly Lazy<HttpClient> _singleHttpClient = new(() => new HttpClient(), true);
     private HttpClientConfiguration? _singleHttpClientConfiguration;
-    private readonly SurrealDbHttpEngineConfig _config = new();
+    private readonly SurrealDbHttpEngineConfig _config;
 
     private int _pendingRequests;
 
@@ -87,6 +87,7 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
         _prependJsonSerializerContexts = prependJsonSerializerContexts;
         _appendJsonSerializerContexts = appendJsonSerializerContexts;
         _configureCborOptions = configureCborOptions;
+        _config = new(_parameters);
     }
 
     public async Task Authenticate(Jwt jwt, CancellationToken cancellationToken)
@@ -111,24 +112,6 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
 
         var request = new SurrealDbHttpRequest { Method = "clear" };
         await ExecuteRequestAsync(request, cancellationToken).ConfigureAwait(false);
-    }
-
-    public void Configure(string? ns, string? db, string? username, string? password)
-    {
-        if (ns is not null)
-            _config.Use(ns, db);
-
-        if (username is not null)
-            _config.SetBasicAuth(username, password);
-    }
-
-    public void Configure(string? ns, string? db, string? token = null)
-    {
-        if (ns is not null)
-            _config.Use(ns, db);
-
-        if (token is not null)
-            _config.SetBearerAuth(token);
     }
 
     public async Task Connect(CancellationToken cancellationToken)

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Interface.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Interface.cs
@@ -1,7 +1,7 @@
-using Dahomey.Cbor;
-using Microsoft.Extensions.ObjectPool;
+﻿using Dahomey.Cbor;
 using SurrealDb.Net.Internals.Models;
 using SurrealDb.Net.Internals.Models.LiveQuery;
+using SurrealDb.Net.Internals.ObjectPool;
 using SurrealDb.Net.Models;
 using SurrealDb.Net.Models.Auth;
 using SurrealDb.Net.Models.LiveQuery;
@@ -10,7 +10,7 @@ using SystemTextJsonPatch;
 
 namespace SurrealDb.Net.Internals;
 
-public interface ISurrealDbEngine : IDisposable, IResettable
+public interface ISurrealDbEngine : IDisposable, IAsyncResettable
 {
 #if DEBUG
     string Id { get; }

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Interface.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Interface.cs
@@ -18,8 +18,6 @@ public interface ISurrealDbEngine : IDisposable, IResettable
 
     Task Authenticate(Jwt jwt, CancellationToken cancellationToken);
     Task Clear(CancellationToken cancellationToken);
-    void Configure(string? ns, string? db, string? username, string? password);
-    void Configure(string? ns, string? db, string? token = null);
     Task Connect(CancellationToken cancellationToken);
     Task<T> Create<T>(T data, CancellationToken cancellationToken)
         where T : Record;

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Interface.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Interface.cs
@@ -1,4 +1,5 @@
-﻿using Dahomey.Cbor;
+using Dahomey.Cbor;
+using Microsoft.Extensions.ObjectPool;
 using SurrealDb.Net.Internals.Models;
 using SurrealDb.Net.Internals.Models.LiveQuery;
 using SurrealDb.Net.Models;
@@ -9,9 +10,14 @@ using SystemTextJsonPatch;
 
 namespace SurrealDb.Net.Internals;
 
-public interface ISurrealDbEngine : IDisposable
+public interface ISurrealDbEngine : IDisposable, IResettable
 {
+#if DEBUG
+    string Id { get; }
+#endif
+
     Task Authenticate(Jwt jwt, CancellationToken cancellationToken);
+    Task Clear(CancellationToken cancellationToken);
     void Configure(string? ns, string? db, string? username, string? password);
     void Configure(string? ns, string? db, string? token = null);
     Task Connect(CancellationToken cancellationToken);

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
@@ -1061,7 +1061,7 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         return liveQueryChannel;
     }
 
-    public bool TryReset()
+    public async Task<bool> TryResetAsync()
     {
         try
         {
@@ -1073,13 +1073,13 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
             }
 
             // Clear server context
-            Clear(default).ConfigureAwait(false).GetAwaiter().GetResult();
+            await Clear(default).ConfigureAwait(false);
 
             // Reset configuration
             _config.Reset(_parameters);
 
             // Apply configuration for connection reuse (neutral state)
-            ApplyConfigurationAsync(default).ConfigureAwait(false).GetAwaiter().GetResult();
+            await ApplyConfigurationAsync(default).ConfigureAwait(false);
 
             // Close Live Queries
             var endChannelsTasks = new List<Task>();
@@ -1109,7 +1109,7 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
             {
                 try
                 {
-                    Task.WhenAll(endChannelsTasks).ConfigureAwait(false).GetAwaiter().GetResult();
+                    await Task.WhenAll(endChannelsTasks).ConfigureAwait(false);
                 }
                 catch (SurrealDbException) { }
                 catch (OperationCanceledException) { }

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
@@ -61,7 +61,7 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     private readonly Func<JsonSerializerContext[]>? _prependJsonSerializerContexts;
     private readonly Func<JsonSerializerContext[]>? _appendJsonSerializerContexts;
     private readonly Action<CborOptions>? _configureCborOptions;
-    private readonly SurrealDbWsEngineConfig _config = new();
+    private readonly SurrealDbWsEngineConfig _config;
     private readonly WebsocketClient _wsClient;
     private readonly IDisposable _receiverSubscription;
     private readonly ConcurrentDictionary<
@@ -101,6 +101,7 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         _prependJsonSerializerContexts = prependJsonSerializerContexts;
         _appendJsonSerializerContexts = appendJsonSerializerContexts;
         _configureCborOptions = configureCborOptions;
+        _config = new(_parameters);
 
         var clientWebSocketFactory = _useCbor
             ? new Func<ClientWebSocket>(() =>
@@ -350,26 +351,6 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     {
         await SendRequestAsync("clear", null, SurrealDbWsRequestPriority.Normal, cancellationToken)
             .ConfigureAwait(false);
-    }
-
-    public void Configure(string? ns, string? db, string? username, string? password)
-    {
-        // 💡 Pre-configuration before connect
-        if (ns is not null)
-            _config.Use(ns, db);
-
-        if (username is not null)
-            _config.SetBasicAuth(username, password);
-    }
-
-    public void Configure(string? ns, string? db, string? token = null)
-    {
-        // 💡 Pre-configuration before connect
-        if (ns is not null)
-            _config.Use(ns, db);
-
-        if (token is not null)
-            _config.SetBearerAuth(token);
     }
 
     public async Task Connect(CancellationToken cancellationToken)

--- a/SurrealDb.Net/Internals/Ws/SurrealDbWsEngineConfig.cs
+++ b/SurrealDb.Net/Internals/Ws/SurrealDbWsEngineConfig.cs
@@ -1,4 +1,5 @@
-using SurrealDb.Net.Internals.Auth;
+﻿using SurrealDb.Net.Internals.Auth;
+using SurrealDb.Net.Internals.Models;
 
 namespace SurrealDb.Net.Internals.Ws;
 
@@ -24,10 +25,27 @@ internal class SurrealDbWsEngineConfig
         Auth = new BearerAuth(token);
     }
 
-    public void Reset()
+    public void ResetAuth()
     {
-        Ns = null;
-        Db = null;
         Auth = new NoAuth();
+    }
+
+    public void Reset(SurrealDbClientParams @params)
+    {
+        Ns = @params.Ns;
+        Db = @params.Db;
+
+        if (@params.Username is not null)
+        {
+            SetBasicAuth(@params.Username, @params.Password);
+        }
+        else if (@params.Token is not null)
+        {
+            SetBearerAuth(@params.Token);
+        }
+        else
+        {
+            ResetAuth();
+        }
     }
 }

--- a/SurrealDb.Net/Internals/Ws/SurrealDbWsEngineConfig.cs
+++ b/SurrealDb.Net/Internals/Ws/SurrealDbWsEngineConfig.cs
@@ -9,6 +9,11 @@ internal class SurrealDbWsEngineConfig
     public string? Ns { get; private set; }
     public string? Db { get; private set; }
 
+    public SurrealDbWsEngineConfig(SurrealDbClientParams @params)
+    {
+        Reset(@params);
+    }
+
     public void Use(string ns, string? db)
     {
         Ns = ns;

--- a/SurrealDb.Net/Models/LiveQuery/SurrealDbLiveQueryClosureReason.cs
+++ b/SurrealDb.Net/Models/LiveQuery/SurrealDbLiveQueryClosureReason.cs
@@ -3,5 +3,6 @@
 public enum SurrealDbLiveQueryClosureReason
 {
     SocketClosed,
-    QueryKilled
+    QueryKilled,
+    ConnectionTerminated
 }

--- a/SurrealDb.Net/SurrealDb.Net.csproj
+++ b/SurrealDb.Net/SurrealDb.Net.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net8.0</TargetFrameworks>
     
     <IsPackable>true</IsPackable>
     <PackageId>SurrealDb.Net</PackageId>
@@ -13,6 +13,7 @@
 	<PackageReference Include="ConcurrentHashSet" Version="1.3.0" />
 	<PackageReference Include="Dahomey.Cbor" Version="1.24.3" />
 	<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+	<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.6" />
 	<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
 	<PackageReference Include="Microsoft.Spatial" Version="7.18.0" />
 	<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
@@ -31,6 +32,9 @@
 	<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
 	  <_Parameter1>SurrealDb.Net.LiveQuery.Tests</_Parameter1>
 	</AssemblyAttribute>
+  <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+    <_Parameter1>SurrealDb.Net.Tests.Fixtures</_Parameter1>
+  </AssemblyAttribute>
 	<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
 	  <_Parameter1>SurrealDb.Net.Benchmarks</_Parameter1>
 	</AssemblyAttribute>

--- a/SurrealDb.Net/SurrealDbClient.Interface.cs
+++ b/SurrealDb.Net/SurrealDbClient.Interface.cs
@@ -1,4 +1,5 @@
-﻿using SurrealDb.Net.Exceptions;
+﻿using Microsoft.Extensions.ObjectPool;
+using SurrealDb.Net.Exceptions;
 using SurrealDb.Net.Models;
 using SurrealDb.Net.Models.Auth;
 using SurrealDb.Net.Models.LiveQuery;

--- a/SurrealDb.Net/SurrealDbClient.Interface.cs
+++ b/SurrealDb.Net/SurrealDbClient.Interface.cs
@@ -40,23 +40,6 @@ public interface ISurrealDbClient : IDisposable
     Task Authenticate(Jwt jwt, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Configures the client to use a specific namespace and database, with a user-defined root access.
-    /// </summary>
-    /// <param name="ns">The table namespace to use.</param>
-    /// <param name="db">The table database to use.</param>
-    /// <param name="username">The username with root access.</param>
-    /// <param name="password">The password with root access.</param>
-    void Configure(string? ns, string? db, string? username, string? password);
-
-    /// <summary>
-    /// Configures the client to use a specific namespace and database, with a JWT token identifier.
-    /// </summary>
-    /// <param name="ns">The table namespace to use.</param>
-    /// <param name="db">The table database to use.</param>
-    /// <param name="token">The value of the JWT token.</param>
-    void Configure(string? ns, string? db, string? token = null);
-
-    /// <summary>
     /// Connects to the SurrealDB instance. This can improve performance to avoid cold starts.<br /><br />
     ///
     /// * Using HTTP(S) protocol: initializes a new HTTP connection<br />

--- a/SurrealDb.Net/SurrealDbClient.Interface.cs
+++ b/SurrealDb.Net/SurrealDbClient.Interface.cs
@@ -15,7 +15,7 @@ namespace SurrealDb.Net;
 /// The entry point to communicate with a SurrealDB instance.
 /// Authenticate, use namespace/database, execute queries, etc...
 /// </summary>
-public interface ISurrealDbClient : IDisposable
+public interface ISurrealDbClient : IDisposable, IAsyncDisposable
 {
     /// <summary>
     /// The uri linked to the SurrealDB instance target.

--- a/SurrealDb.Net/SurrealDbClient.cs
+++ b/SurrealDb.Net/SurrealDbClient.cs
@@ -3,8 +3,10 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Dahomey.Cbor;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.ObjectPool;
 using SurrealDb.Net.Internals;
 using SurrealDb.Net.Internals.Models;
+using SurrealDb.Net.Internals.ObjectPool;
 using SurrealDb.Net.Models;
 using SurrealDb.Net.Models.Auth;
 using SurrealDb.Net.Models.LiveQuery;
@@ -24,8 +26,11 @@ namespace SurrealDb.Net;
 /// </summary>
 public class SurrealDbClient : ISurrealDbClient
 {
-    private readonly ISurrealDbEngine _engine;
+    private readonly Action? _poolAction;
 
+    internal ISurrealDbEngine Engine { get; }
+
+    // TODO : Retrieve properties from engine
     public Uri Uri { get; }
     public string? NamingPolicy { get; }
 
@@ -107,18 +112,20 @@ public class SurrealDbClient : ISurrealDbClient
         Action<JsonSerializerOptions>? configureJsonSerializerOptions = null,
         Func<JsonSerializerContext[]>? prependJsonSerializerContexts = null,
         Func<JsonSerializerContext[]>? appendJsonSerializerContexts = null,
-        Action<CborOptions>? configureCborOptions = null
+        Action<CborOptions>? configureCborOptions = null,
+        Action? poolAction = null
     )
     {
         if (parameters.Endpoint is null)
             throw new ArgumentNullException(nameof(parameters), "The endpoint is required.");
 
+        _poolAction = poolAction;
         Uri = new Uri(parameters.Endpoint);
         NamingPolicy = parameters.NamingPolicy;
 
         var protocol = Uri.Scheme;
 
-        _engine = protocol switch
+        Engine = protocol switch
         {
             "http"
             or "https"
@@ -153,6 +160,19 @@ public class SurrealDbClient : ISurrealDbClient
             Configure(parameters.Ns, parameters.Db, parameters.Token);
     }
 
+    internal SurrealDbClient(
+        SurrealDbClientParams parameters,
+        ISurrealDbEngine engine,
+        Action? poolAction = null
+    )
+    {
+        Uri = new Uri(parameters.Endpoint!);
+        NamingPolicy = parameters.NamingPolicy;
+
+        Engine = engine;
+        _poolAction = poolAction;
+    }
+
     private static ISurrealDbInMemoryEngine? ResolveInMemoryProvider(
         IServiceProvider? serviceProvider,
         SurrealDbClientParams parameters,
@@ -167,28 +187,28 @@ public class SurrealDbClient : ISurrealDbClient
 
     public Task Authenticate(Jwt jwt, CancellationToken cancellationToken = default)
     {
-        return _engine.Authenticate(jwt, cancellationToken);
+        return Engine.Authenticate(jwt, cancellationToken);
     }
 
     public void Configure(string? ns, string? db, string? username, string? password)
     {
-        _engine.Configure(ns, db, username, password);
+        Engine.Configure(ns, db, username, password);
     }
 
     public void Configure(string? ns, string? db, string? token = null)
     {
-        _engine.Configure(ns, db, token);
+        Engine.Configure(ns, db, token);
     }
 
     public Task Connect(CancellationToken cancellationToken = default)
     {
-        return _engine.Connect(cancellationToken);
+        return Engine.Connect(cancellationToken);
     }
 
     public Task<T> Create<T>(T data, CancellationToken cancellationToken = default)
         where T : Record
     {
-        return _engine.Create(data, cancellationToken);
+        return Engine.Create(data, cancellationToken);
     }
 
     public Task<T> Create<T>(
@@ -197,7 +217,7 @@ public class SurrealDbClient : ISurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return _engine.Create(table, data, cancellationToken);
+        return Engine.Create(table, data, cancellationToken);
     }
 
     public Task<TOutput> Create<TData, TOutput>(
@@ -207,37 +227,44 @@ public class SurrealDbClient : ISurrealDbClient
     )
         where TOutput : Record
     {
-        return _engine.Create<TData, TOutput>(recordId, data, cancellationToken);
+        return Engine.Create<TData, TOutput>(recordId, data, cancellationToken);
     }
 
     public Task Delete(string table, CancellationToken cancellationToken = default)
     {
-        return _engine.Delete(table, cancellationToken);
+        return Engine.Delete(table, cancellationToken);
     }
 
     public Task<bool> Delete(Thing thing, CancellationToken cancellationToken = default)
     {
-        return _engine.Delete(thing, cancellationToken);
+        return Engine.Delete(thing, cancellationToken);
     }
 
     public Task<bool> Delete(StringRecordId recordId, CancellationToken cancellationToken = default)
     {
-        return _engine.Delete(recordId, cancellationToken);
+        return Engine.Delete(recordId, cancellationToken);
     }
 
     public void Dispose()
     {
-        _engine.Dispose();
+        if (_poolAction is not null)
+        {
+            // 💡 Prevent engine disposal as it will be reuse in an object pool
+            _poolAction();
+            return;
+        }
+
+        Engine.Dispose();
     }
 
     public Task<bool> Health(CancellationToken cancellationToken = default)
     {
-        return _engine.Health(cancellationToken);
+        return Engine.Health(cancellationToken);
     }
 
     public Task<T> Info<T>(CancellationToken cancellationToken = default)
     {
-        return _engine.Info<T>(cancellationToken);
+        return Engine.Info<T>(cancellationToken);
     }
 
     public Task<IEnumerable<T>> Insert<T>(
@@ -247,17 +274,17 @@ public class SurrealDbClient : ISurrealDbClient
     )
         where T : Record
     {
-        return _engine.Insert(table, data, cancellationToken);
+        return Engine.Insert(table, data, cancellationToken);
     }
 
     public Task Invalidate(CancellationToken cancellationToken = default)
     {
-        return _engine.Invalidate(cancellationToken);
+        return Engine.Invalidate(cancellationToken);
     }
 
     public Task Kill(Guid queryUuid, CancellationToken cancellationToken = default)
     {
-        return _engine.Kill(
+        return Engine.Kill(
             queryUuid,
             SurrealDbLiveQueryClosureReason.QueryKilled,
             cancellationToken
@@ -266,7 +293,7 @@ public class SurrealDbClient : ISurrealDbClient
 
     public SurrealDbLiveQuery<T> ListenLive<T>(Guid queryUuid)
     {
-        return _engine.ListenLive<T>(queryUuid);
+        return Engine.ListenLive<T>(queryUuid);
     }
 
 #if NET6_0_OR_GREATER
@@ -275,7 +302,7 @@ public class SurrealDbClient : ISurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return _engine.LiveRawQuery<T>(query.FormattedText, query.Parameters, cancellationToken);
+        return Engine.LiveRawQuery<T>(query.FormattedText, query.Parameters, cancellationToken);
     }
 #else
     public Task<SurrealDbLiveQuery<T>> LiveQuery<T>(
@@ -284,7 +311,7 @@ public class SurrealDbClient : ISurrealDbClient
     )
     {
         var (formattedQuery, parameters) = query.ExtractRawQueryParams();
-        return _engine.LiveRawQuery<T>(formattedQuery, parameters, cancellationToken);
+        return Engine.LiveRawQuery<T>(formattedQuery, parameters, cancellationToken);
     }
 #endif
 
@@ -294,7 +321,7 @@ public class SurrealDbClient : ISurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return _engine.LiveRawQuery<T>(
+        return Engine.LiveRawQuery<T>(
             query,
             parameters ?? ImmutableDictionary<string, object?>.Empty,
             cancellationToken
@@ -307,7 +334,7 @@ public class SurrealDbClient : ISurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return _engine.LiveTable<T>(table, diff, cancellationToken);
+        return Engine.LiveTable<T>(table, diff, cancellationToken);
     }
 
     public Task<TOutput> Merge<TMerge, TOutput>(
@@ -316,7 +343,7 @@ public class SurrealDbClient : ISurrealDbClient
     )
         where TMerge : Record
     {
-        return _engine.Merge<TMerge, TOutput>(data, cancellationToken);
+        return Engine.Merge<TMerge, TOutput>(data, cancellationToken);
     }
 
     public Task<T> Merge<T>(
@@ -325,7 +352,7 @@ public class SurrealDbClient : ISurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return _engine.Merge<T>(thing, data, cancellationToken);
+        return Engine.Merge<T>(thing, data, cancellationToken);
     }
 
     public Task<T> Merge<T>(
@@ -334,7 +361,7 @@ public class SurrealDbClient : ISurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return _engine.Merge<T>(recordId, data, cancellationToken);
+        return Engine.Merge<T>(recordId, data, cancellationToken);
     }
 
     public Task<IEnumerable<TOutput>> MergeAll<TMerge, TOutput>(
@@ -344,7 +371,7 @@ public class SurrealDbClient : ISurrealDbClient
     )
         where TMerge : class
     {
-        return _engine.MergeAll<TMerge, TOutput>(table, data, cancellationToken);
+        return Engine.MergeAll<TMerge, TOutput>(table, data, cancellationToken);
     }
 
     public Task<IEnumerable<T>> MergeAll<T>(
@@ -353,7 +380,7 @@ public class SurrealDbClient : ISurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return _engine.MergeAll<T>(table, data, cancellationToken);
+        return Engine.MergeAll<T>(table, data, cancellationToken);
     }
 
     public Task<T> Patch<T>(
@@ -363,7 +390,7 @@ public class SurrealDbClient : ISurrealDbClient
     )
         where T : class
     {
-        return _engine.Patch(thing, patches, cancellationToken);
+        return Engine.Patch(thing, patches, cancellationToken);
     }
 
     public Task<T> Patch<T>(
@@ -373,7 +400,7 @@ public class SurrealDbClient : ISurrealDbClient
     )
         where T : class
     {
-        return _engine.Patch(recordId, patches, cancellationToken);
+        return Engine.Patch(recordId, patches, cancellationToken);
     }
 
     public Task<IEnumerable<T>> PatchAll<T>(
@@ -383,7 +410,7 @@ public class SurrealDbClient : ISurrealDbClient
     )
         where T : class
     {
-        return _engine.PatchAll(table, patches, cancellationToken);
+        return Engine.PatchAll(table, patches, cancellationToken);
     }
 
 #if NET6_0_OR_GREATER
@@ -392,7 +419,7 @@ public class SurrealDbClient : ISurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return _engine.RawQuery(query.FormattedText, query.Parameters, cancellationToken);
+        return Engine.RawQuery(query.FormattedText, query.Parameters, cancellationToken);
     }
 #else
     public Task<SurrealDbResponse> Query(
@@ -401,7 +428,7 @@ public class SurrealDbClient : ISurrealDbClient
     )
     {
         var (formattedQuery, parameters) = query.ExtractRawQueryParams();
-        return _engine.RawQuery(formattedQuery, parameters, cancellationToken);
+        return Engine.RawQuery(formattedQuery, parameters, cancellationToken);
     }
 #endif
 
@@ -411,7 +438,7 @@ public class SurrealDbClient : ISurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return _engine.RawQuery(
+        return Engine.RawQuery(
             query,
             parameters ?? ImmutableDictionary<string, object?>.Empty,
             cancellationToken
@@ -426,7 +453,7 @@ public class SurrealDbClient : ISurrealDbClient
     )
         where TOutput : class
     {
-        var outputs = await _engine
+        var outputs = await Engine
             .Relate<TOutput, object>(table, new[] { @in }, new[] { @out }, null, cancellationToken)
             .ConfigureAwait(false);
 
@@ -442,7 +469,7 @@ public class SurrealDbClient : ISurrealDbClient
     )
         where TOutput : class
     {
-        var outputs = await _engine
+        var outputs = await Engine
             .Relate<TOutput, TData>(table, new[] { @in }, new[] { @out }, data, cancellationToken)
             .ConfigureAwait(false);
 
@@ -457,7 +484,7 @@ public class SurrealDbClient : ISurrealDbClient
     )
         where TOutput : class
     {
-        return _engine.Relate<TOutput, object>(table, ins, new[] { @out }, null, cancellationToken);
+        return Engine.Relate<TOutput, object>(table, ins, new[] { @out }, null, cancellationToken);
     }
 
     public Task<IEnumerable<TOutput>> Relate<TOutput, TData>(
@@ -469,7 +496,7 @@ public class SurrealDbClient : ISurrealDbClient
     )
         where TOutput : class
     {
-        return _engine.Relate<TOutput, TData>(table, ins, new[] { @out }, data, cancellationToken);
+        return Engine.Relate<TOutput, TData>(table, ins, new[] { @out }, data, cancellationToken);
     }
 
     public Task<IEnumerable<TOutput>> Relate<TOutput>(
@@ -480,7 +507,7 @@ public class SurrealDbClient : ISurrealDbClient
     )
         where TOutput : class
     {
-        return _engine.Relate<TOutput, object>(table, new[] { @in }, outs, null, cancellationToken);
+        return Engine.Relate<TOutput, object>(table, new[] { @in }, outs, null, cancellationToken);
     }
 
     public Task<IEnumerable<TOutput>> Relate<TOutput, TData>(
@@ -492,7 +519,7 @@ public class SurrealDbClient : ISurrealDbClient
     )
         where TOutput : class
     {
-        return _engine.Relate<TOutput, TData>(table, new[] { @in }, outs, data, cancellationToken);
+        return Engine.Relate<TOutput, TData>(table, new[] { @in }, outs, data, cancellationToken);
     }
 
     public Task<IEnumerable<TOutput>> Relate<TOutput>(
@@ -503,7 +530,7 @@ public class SurrealDbClient : ISurrealDbClient
     )
         where TOutput : class
     {
-        return _engine.Relate<TOutput, object>(table, ins, outs, null, cancellationToken);
+        return Engine.Relate<TOutput, object>(table, ins, outs, null, cancellationToken);
     }
 
     public Task<IEnumerable<TOutput>> Relate<TOutput, TData>(
@@ -515,7 +542,7 @@ public class SurrealDbClient : ISurrealDbClient
     )
         where TOutput : class
     {
-        return _engine.Relate<TOutput, TData>(table, ins, outs, data, cancellationToken);
+        return Engine.Relate<TOutput, TData>(table, ins, outs, data, cancellationToken);
     }
 
     public Task<TOutput> Relate<TOutput>(
@@ -526,7 +553,7 @@ public class SurrealDbClient : ISurrealDbClient
     )
         where TOutput : class
     {
-        return _engine.Relate<TOutput, object>(thing, @in, @out, null, cancellationToken);
+        return Engine.Relate<TOutput, object>(thing, @in, @out, null, cancellationToken);
     }
 
     public Task<TOutput> Relate<TOutput, TData>(
@@ -538,7 +565,7 @@ public class SurrealDbClient : ISurrealDbClient
     )
         where TOutput : class
     {
-        return _engine.Relate<TOutput, TData>(thing, @in, @out, data, cancellationToken);
+        return Engine.Relate<TOutput, TData>(thing, @in, @out, data, cancellationToken);
     }
 
     public Task<IEnumerable<T>> Select<T>(
@@ -546,12 +573,12 @@ public class SurrealDbClient : ISurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return _engine.Select<T>(table, cancellationToken);
+        return Engine.Select<T>(table, cancellationToken);
     }
 
     public Task<T?> Select<T>(Thing thing, CancellationToken cancellationToken = default)
     {
-        return _engine.Select<T?>(thing, cancellationToken);
+        return Engine.Select<T?>(thing, cancellationToken);
     }
 
     public Task<T?> Select<T>(
@@ -559,44 +586,44 @@ public class SurrealDbClient : ISurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return _engine.Select<T?>(recordId, cancellationToken);
+        return Engine.Select<T?>(recordId, cancellationToken);
     }
 
     public Task Set(string key, object value, CancellationToken cancellationToken = default)
     {
-        return _engine.Set(key, value, cancellationToken);
+        return Engine.Set(key, value, cancellationToken);
     }
 
     public Task SignIn(RootAuth root, CancellationToken cancellationToken = default)
     {
-        return _engine.SignIn(root, cancellationToken);
+        return Engine.SignIn(root, cancellationToken);
     }
 
     public Task<Jwt> SignIn(NamespaceAuth nsAuth, CancellationToken cancellationToken = default)
     {
-        return _engine.SignIn(nsAuth, cancellationToken);
+        return Engine.SignIn(nsAuth, cancellationToken);
     }
 
     public Task<Jwt> SignIn(DatabaseAuth dbAuth, CancellationToken cancellationToken = default)
     {
-        return _engine.SignIn(dbAuth, cancellationToken);
+        return Engine.SignIn(dbAuth, cancellationToken);
     }
 
     public Task<Jwt> SignIn<T>(T scopeAuth, CancellationToken cancellationToken = default)
         where T : ScopeAuth
     {
-        return _engine.SignIn(scopeAuth, cancellationToken);
+        return Engine.SignIn(scopeAuth, cancellationToken);
     }
 
     public Task<Jwt> SignUp<T>(T scopeAuth, CancellationToken cancellationToken = default)
         where T : ScopeAuth
     {
-        return _engine.SignUp(scopeAuth, cancellationToken);
+        return Engine.SignUp(scopeAuth, cancellationToken);
     }
 
     public Task Unset(string key, CancellationToken cancellationToken = default)
     {
-        return _engine.Unset(key, cancellationToken);
+        return Engine.Unset(key, cancellationToken);
     }
 
     public Task<IEnumerable<T>> UpdateAll<T>(
@@ -606,13 +633,13 @@ public class SurrealDbClient : ISurrealDbClient
     )
         where T : class
     {
-        return _engine.UpdateAll(table, data, cancellationToken);
+        return Engine.UpdateAll(table, data, cancellationToken);
     }
 
     public Task<T> Upsert<T>(T data, CancellationToken cancellationToken = default)
         where T : Record
     {
-        return _engine.Upsert(data, cancellationToken);
+        return Engine.Upsert(data, cancellationToken);
     }
 
     public Task<TOutput> Upsert<TData, TOutput>(
@@ -622,16 +649,16 @@ public class SurrealDbClient : ISurrealDbClient
     )
         where TOutput : Record
     {
-        return _engine.Upsert<TData, TOutput>(recordId, data, cancellationToken);
+        return Engine.Upsert<TData, TOutput>(recordId, data, cancellationToken);
     }
 
     public Task Use(string ns, string db, CancellationToken cancellationToken = default)
     {
-        return _engine.Use(ns, db, cancellationToken);
+        return Engine.Use(ns, db, cancellationToken);
     }
 
     public Task<string> Version(CancellationToken cancellationToken = default)
     {
-        return _engine.Version(cancellationToken);
+        return Engine.Version(cancellationToken);
     }
 }

--- a/SurrealDb.Net/SurrealDbClient.cs
+++ b/SurrealDb.Net/SurrealDbClient.cs
@@ -26,7 +26,7 @@ namespace SurrealDb.Net;
 /// </summary>
 public class SurrealDbClient : ISurrealDbClient
 {
-    private readonly Action? _poolAction;
+    private readonly Func<Task>? _poolTask;
 
     internal ISurrealDbEngine Engine { get; }
 
@@ -113,13 +113,13 @@ public class SurrealDbClient : ISurrealDbClient
         Func<JsonSerializerContext[]>? prependJsonSerializerContexts = null,
         Func<JsonSerializerContext[]>? appendJsonSerializerContexts = null,
         Action<CborOptions>? configureCborOptions = null,
-        Action? poolAction = null
+        Func<Task>? poolTask = null
     )
     {
         if (parameters.Endpoint is null)
             throw new ArgumentNullException(nameof(parameters), "The endpoint is required.");
 
-        _poolAction = poolAction;
+        _poolTask = poolTask;
         Uri = new Uri(parameters.Endpoint);
         NamingPolicy = parameters.NamingPolicy;
 
@@ -158,14 +158,14 @@ public class SurrealDbClient : ISurrealDbClient
     internal SurrealDbClient(
         SurrealDbClientParams parameters,
         ISurrealDbEngine engine,
-        Action? poolAction = null
+        Func<Task>? poolTask = null
     )
     {
         Uri = new Uri(parameters.Endpoint!);
         NamingPolicy = parameters.NamingPolicy;
 
         Engine = engine;
-        _poolAction = poolAction;
+        _poolTask = poolTask;
     }
 
     private static ISurrealDbInMemoryEngine? ResolveInMemoryProvider(
@@ -232,14 +232,19 @@ public class SurrealDbClient : ISurrealDbClient
 
     public void Dispose()
     {
-        if (_poolAction is not null)
+        Engine.Dispose();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_poolTask is not null)
         {
             // 💡 Prevent engine disposal as it will be reuse in an object pool
-            _poolAction();
+            await _poolTask.Invoke().ConfigureAwait(false);
             return;
         }
 
-        Engine.Dispose();
+        Dispose();
     }
 
     public Task<bool> Health(CancellationToken cancellationToken = default)

--- a/SurrealDb.Net/SurrealDbClient.cs
+++ b/SurrealDb.Net/SurrealDbClient.cs
@@ -153,11 +153,6 @@ public class SurrealDbClient : ISurrealDbClient
                     ),
             _ => throw new NotSupportedException($"The protocol '{protocol}' is not supported."),
         };
-
-        if (parameters.Username is not null)
-            Configure(parameters.Ns, parameters.Db, parameters.Username, parameters.Password);
-        else
-            Configure(parameters.Ns, parameters.Db, parameters.Token);
     }
 
     internal SurrealDbClient(
@@ -188,16 +183,6 @@ public class SurrealDbClient : ISurrealDbClient
     public Task Authenticate(Jwt jwt, CancellationToken cancellationToken = default)
     {
         return Engine.Authenticate(jwt, cancellationToken);
-    }
-
-    public void Configure(string? ns, string? db, string? username, string? password)
-    {
-        Engine.Configure(ns, db, username, password);
-    }
-
-    public void Configure(string? ns, string? db, string? token = null)
-    {
-        Engine.Configure(ns, db, token);
     }
 
     public Task Connect(CancellationToken cancellationToken = default)


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What does this change do?

SurrealDbClient pooling to avoid the cost of

1. WS reconnection when using the websocket engine
2. dropping and creating engines over and over, reducing memory pressure

The embedded modes are not concerned as of now.

## What is your testing strategy?

Integrations tests & manual tests

## Is this related to any issues?

Fixes #104 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)