### PR TITLE
Fix .NET SDK issue by specifying a namespace

### DIFF
--- a/SurrealDb.Net/Internals/Constants/HttpConstants.cs
+++ b/SurrealDb.Net/Internals/Constants/HttpConstants.cs
@@ -3,6 +3,6 @@
 internal static class HttpConstants
 {
     public const string ACCEPT_HEADER_NAME = "Accept";
-    public const string NS_HEADER_NAME = "NS";
-    public const string DB_HEADER_NAME = "DB";
+    public const string NS_HEADER_NAME = "surreal-ns";
+    public const string DB_HEADER_NAME = "surreal-db";
 }


### PR DESCRIPTION
## What is the motivation?

The SDK was encountering errors with various operations (e.g., QUERY, RAWQUERY, SET, UPSERT) that interact directly with the database. This commit fixes the issue for SurrealDB V2.X, but it is not compatible with V1.X.

## What does this change do?

Fixes #127:
Changes included:
-  Updated const strings for HTTP request headers from 'NS' to 'surrealdb-ns' and 'DB' to 'surrealdb-db'.

## What is your testing strategy?

### Manual Testing

Initially, I encountered the error: There was a problem with the database: Specify a namespace to use when performing various database operations such as upsert, query, rawquery, set, and create.
To reproduce the issue, I created a simple .NET project with two types of applications: a console app and an MVC app with Dependency Injection (DI). I executed the operations that were triggering the error in both environments.
After identifying the root cause of the error, I applied a fix by ensuring that the correct namespace is specified in the HTTP headers.
I repeated the same operations (upsert, query, rawquery, set, and create) multiple times, confirming that the error no longer occurred and the database interactions proceeded as expected.
Additional Tests:

I tested multiple rawquery operations, created several sets and create operations, ensuring that the fix worked consistently across different scenarios and types of operations.
All tests passed without errors, and the operations successfully interacted with the correct namespace and database.

### How to Verify the Changes:
- Ensure you are using SurrealDB V2.X.
- Create a .NET project (console or MVC) and include the SDK.
- Perform the following operations: upsert, query, rawquery, set, and create.
Verify that the correct namespace is being used and that no errors related to namespace specification are thrown.
The operations should complete without errors, and the data should be correctly inserted or queried from the database.

>[!IMPORTANT]
> These changes are only supported in SurrealDB V2.X and will not work with V1.X.

## Is this related to any issues?
Issue #127 

https://github.com/surrealdb/surrealdb.net/issues/127

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)?

- [ x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)