### PR TITLE
🐛 fix missing error details on Query response

### DIFF
--- a/SurrealDb.Net/Internals/Cbor/Converters/SurrealDbResultConverter.cs
+++ b/SurrealDb.Net/Internals/Cbor/Converters/SurrealDbResultConverter.cs
@@ -105,6 +105,12 @@ internal class SurrealDbResultConverter : CborConverterBase<ISurrealDbResult>
                 return new SurrealDbOkResult(time, status, result.Value, _options);
             }
 
+            if (result.HasValue)
+            {
+                string errorFromResult = CborSerializer.Deserialize<string>(result.Value.Span);
+                return new SurrealDbErrorResult(time, status, errorFromResult);
+            }
+
             return new SurrealDbErrorResult(time, status, errorDetails!);
         }
 

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
@@ -95,9 +95,9 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 
                         if (message.MessageType == WebSocketMessageType.Binary)
                         {
-                            using var stream = message.Stream is not null
-                                ? message.Stream
-                                : MemoryStreamProvider.MemoryStreamManager.GetStream(
+                            using var stream =
+                                message.Stream
+                                ?? MemoryStreamProvider.MemoryStreamManager.GetStream(
                                     message.Binary!
                                 );
 
@@ -117,16 +117,14 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
                             if (
                                 _liveQueryChannelSubscriptionsPerQuery.TryGetValue(
                                     liveQueryUuid,
-                                    out var _liveQueryChannelSubscriptions
+                                    out var liveQueryChannelSubscriptions
                                 )
                             )
                             {
-                                var tasks = _liveQueryChannelSubscriptions.Select(
-                                    liveQueryChannel =>
-                                    {
-                                        return liveQueryChannel.WriteAsync(surrealDbWsLiveResponse);
-                                    }
-                                );
+                                var tasks = liveQueryChannelSubscriptions.Select(liveQueryChannel =>
+                                {
+                                    return liveQueryChannel.WriteAsync(surrealDbWsLiveResponse);
+                                });
 
                                 await Task.WhenAll(tasks).ConfigureAwait(false);
                             }
@@ -189,11 +187,11 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
                         value.WsEngineId == _id
                         && _liveQueryChannelSubscriptionsPerQuery.TryRemove(
                             key,
-                            out var _liveQueryChannelSubscriptions
+                            out var liveQueryChannelSubscriptions
                         )
                     )
                     {
-                        foreach (var liveQueryChannel in _liveQueryChannelSubscriptions)
+                        foreach (var liveQueryChannel in liveQueryChannelSubscriptions)
                         {
                             var closeTask = CloseLiveQueryAsync(
                                 liveQueryChannel,


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What does this change do?

Handle the error details of surrealdb Result that is now stored in the `result` property.

## What is your testing strategy?

Integration tests

## Is this related to any issues?

Fixes #135 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)