### PR TITLE
fix: corrected datetime serialisation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,13 +6,14 @@
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.10" />
     <PackageVersion Include="Bogus" Version="35.5.1" />
-	  <PackageVersion Include="ConcurrentHashSet" Version="1.3.0" />
+    <PackageVersion Include="ConcurrentHashSet" Version="1.3.0" />
     <PackageVersion Include="coverlet.collector" Version="3.1.2" />
     <PackageVersion Include="csbindgen" Version="1.9.1" />
     <PackageVersion Include="CSharpier.MsBuild" Version="0.27.3" />
     <PackageVersion Include="Dahomey.Cbor" Version="1.24.3" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.1.1" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="FsCheck.Xunit" Version="2.16.6" />
     <PackageVersion Include="Meziantou.Xunit.ParallelTestFramework" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />

--- a/SurrealDb.Net.Tests/ParserTests.cs
+++ b/SurrealDb.Net.Tests/ParserTests.cs
@@ -981,6 +981,14 @@ public class ParserTests
                 .Value.Should()
                 .Be(new DateTime(2022, 7, 3, 7, 18, 52).AddNanoseconds(123_456_789));
         }
+
+        {
+            var problematicRecord = records.First(r => r.Name == "problematic");
+            problematicRecord.Should().NotBeNull();
+            problematicRecord!
+                .Value.Should()
+                .Be(new DateTime(1913, 6, 3, 14, 38, 30).AddNanoseconds(164_000_000));
+        }
     }
 
     [Theory]

--- a/SurrealDb.Net.Tests/Schemas/datetime.surql
+++ b/SurrealDb.Net.Tests/Schemas/datetime.surql
@@ -10,3 +10,4 @@ CREATE datetime SET name = "timezone", value = d"2022-07-03T07:18:52.841147+02:0
 CREATE datetime SET name = "time+duration", value = d"2022-07-03T07:18:52Z" + 2w;
 CREATE datetime SET name = "nano+duration", value = d"2022-07-03T07:18:52.841147Z" + 1h30m20s1350ms;
 CREATE datetime SET name = "full-nano", value = d"2022-07-03T07:18:52.123456789Z";
+CREATE datetime SET name = "problematic", value = d"1913-06-03T14:38:30.1640000Z";

--- a/SurrealDb.Net.Tests/Serializers/Cbor/BaseCborConverterTests.cs
+++ b/SurrealDb.Net.Tests/Serializers/Cbor/BaseCborConverterTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Buffers;
+using System.Text;
 using SurrealDb.Net.Internals.Cbor;
 
 namespace SurrealDb.Net.Tests.Serializers.Cbor;
@@ -45,5 +46,18 @@ public abstract class BaseCborConverterTests
         }
 
         return bytes;
+    }
+
+    protected ReadOnlySpan<byte> SerializeToCborBinary<T>(T value)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        CborSerializer.Serialize(value, buffer, SurrealDbCborOptions.Default);
+
+        return buffer.WrittenMemory.Span;
+    }
+
+    protected T DeserializeCborBinary<T>(ReadOnlySpan<byte> bytes)
+    {
+        return CborSerializer.Deserialize<T>(bytes, SurrealDbCborOptions.Default);
     }
 }

--- a/SurrealDb.Net.Tests/Serializers/Cbor/DateTimeConverterTests.cs
+++ b/SurrealDb.Net.Tests/Serializers/Cbor/DateTimeConverterTests.cs
@@ -1,7 +1,20 @@
-﻿namespace SurrealDb.Net.Tests.Serializers.Cbor;
+﻿using System.Buffers;
+using Dahomey.Cbor;
+using FsCheck.Xunit;
+using SurrealDb.Net.Internals.Cbor;
+using Xunit.Abstractions;
+
+namespace SurrealDb.Net.Tests.Serializers.Cbor;
 
 public class DateTimeConverterTests : BaseCborConverterTests
 {
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public DateTimeConverterTests(ITestOutputHelper testOutputHelper)
+    {
+        _testOutputHelper = testOutputHelper;
+    }
+
     [Fact]
     public async Task Serialize()
     {
@@ -20,5 +33,27 @@ public class DateTimeConverterTests : BaseCborConverterTests
         var expected = DateTime.Parse("2024-03-24T13:30:26.1623225Z").ToUniversalTime();
 
         result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void ShouldSerializeAndDeserializeDateTime()
+    {
+        var expected = DateTime.Parse("1913-06-03T14:38:30.1640000Z").ToUniversalTime();
+
+        var serialized = SerializeToCborBinary(expected);
+        var deserialized = DeserializeCborBinary<DateTime>(serialized);
+
+        deserialized.Should().Be(expected);
+    }
+
+    [Property(DisplayName = "When given a datetime it should serialize and deserialize correctly")]
+    public bool DateTimeSerialization(DateTime expected)
+    {
+        var utc = expected.ToUniversalTime();
+
+        var serialized = SerializeToCborBinary(utc);
+        var deserialized = DeserializeCborBinary<DateTime>(serialized);
+
+        return deserialized.Equals(utc);
     }
 }

--- a/SurrealDb.Net.Tests/SurrealDb.Net.Tests.csproj
+++ b/SurrealDb.Net.Tests/SurrealDb.Net.Tests.csproj
@@ -6,6 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="FsCheck.Xunit" />
         <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Semver" />

--- a/SurrealDb.Net/Internals/Parsers/DateTimeParser.cs
+++ b/SurrealDb.Net/Internals/Parsers/DateTimeParser.cs
@@ -1,13 +1,10 @@
-﻿using SurrealDb.Net.Internals.Constants;
-
-namespace SurrealDb.Net.Internals.Parsers;
+﻿namespace SurrealDb.Net.Internals.Parsers;
 
 internal static partial class DateTimeParser
 {
     public static DateTime Convert(long seconds, int nanos)
     {
-        return DateTime
-            .UnixEpoch.AddSeconds(seconds)
-            .AddTicks((long)Math.Round((double)nanos / TimeConstants.NanosecondsPerTick));
+        var ns = (long)Math.Round((float)nanos / 100);
+        return DateTime.UnixEpoch.AddTicks((seconds * TimeSpan.TicksPerSecond) + ns);
     }
 }


### PR DESCRIPTION
property based testing revealed a number of values that failed to maintain their value when round tripped through serialization/deserialization. T

## What is the motivation?

I required that data time values are consistent when serialised

## What does this change do?

This commit adds a property based test for datetime values and corrects the issue with serialisation.

## What is your testing strategy?

Added fscheck based tests for data time serialisation as well as a specific value sample. also added a specific value example in the database round trip tests for date time

## Is this related to any issues?

addresses the date time portion of https://github.com/surrealdb/surrealdb.net/issues/138

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)?

- [ x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)