### PR TITLE
🚸 automatically add `/rpc` suffix for ws protocols

### DIFF
--- a/SurrealDb.Net.Tests/ConstructorTests.cs
+++ b/SurrealDb.Net.Tests/ConstructorTests.cs
@@ -38,6 +38,21 @@ public class ConstructorTests
         func().AbsoluteUri.Should().Be("wss://cloud.surrealdb.com/rpc");
     }
 
+    [Theory]
+    [InlineData("ws://127.0.0.1:8000", "ws://127.0.0.1:8000/rpc")]
+    [InlineData("wss://cloud.SurrealDb.com", "wss://cloud.surrealdb.com/rpc")]
+    [InlineData("ws://127.0.0.1:8000/", "ws://127.0.0.1:8000/rpc")]
+    [InlineData("wss://cloud.SurrealDb.com/", "wss://cloud.surrealdb.com/rpc")]
+    [InlineData("ws://127.0.0.1:8000/bar", "ws://127.0.0.1:8000/bar/rpc")]
+    [InlineData("wss://cloud.SurrealDb.com/bar", "wss://cloud.surrealdb.com/bar/rpc")]
+    public void ShouldAutomaticallyAddRpcSuffixForWsProtocols(string endpoint, string expected)
+    {
+        Func<Uri> func = () => new SurrealDbClient(endpoint).Uri;
+
+        func.Should().NotThrow();
+        func().AbsoluteUri.Should().Be(expected);
+    }
+
     [Fact]
     public void ShouldRequireDependencyInjectionForMemoryProtocol()
     {

--- a/SurrealDb.Net/SurrealDbClient.cs
+++ b/SurrealDb.Net/SurrealDbClient.cs
@@ -68,6 +68,14 @@ public class SurrealDbClient : BaseSurrealDbClient, ISurrealDbClient
             throw new ArgumentNullException(nameof(configuration), "The endpoint is required.");
 
         Uri = new Uri(configuration.Endpoint);
+        if (Uri.Scheme is "ws" or "wss" && !Uri.AbsolutePath.EndsWith("/rpc"))
+        {
+            string absoluteNakedPath = Uri.AbsolutePath.EndsWith("/")
+                ? Uri.AbsolutePath[..^1]
+                : Uri.AbsolutePath;
+            Uri = new Uri(Uri, $"{absoluteNakedPath}/rpc");
+        }
+
         NamingPolicy = configuration.NamingPolicy;
 
         var protocol = Uri.Scheme;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What does this change do?

Add `/rpc` suffix to prevent issue when providing an incomplete WS endpoint.

## What is your testing strategy?

Unit test

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)