### PR TITLE
🐛 fix request before connect

### DIFF
--- a/SurrealDb.Embedded.Internals/SurrealDbEmbeddedEngine.cs
+++ b/SurrealDb.Embedded.Internals/SurrealDbEmbeddedEngine.cs
@@ -27,7 +27,7 @@ internal sealed partial class SurrealDbEmbeddedEngine : ISurrealDbProviderEngine
     private ISurrealDbLoggerFactory? _surrealDbLoggerFactory;
 
     private readonly int _id;
-    private readonly SurrealDbEmbeddedEngineConfig _config = new();
+    private SurrealDbEmbeddedEngineConfig _config = new();
 
     private bool _isConnected;
     private bool _isInitialized;
@@ -51,6 +51,7 @@ internal sealed partial class SurrealDbEmbeddedEngine : ISurrealDbProviderEngine
         _parameters = parameters;
         _configureCborOptions = configureCborOptions;
         _surrealDbLoggerFactory = surrealDbLoggerFactory;
+        _config = new(_parameters);
     }
 
     public Task Authenticate(Jwt jwt, CancellationToken cancellationToken)

--- a/SurrealDb.Embedded.Internals/SurrealDbEmbeddedEngineConfig.cs
+++ b/SurrealDb.Embedded.Internals/SurrealDbEmbeddedEngineConfig.cs
@@ -1,18 +1,22 @@
-﻿namespace SurrealDb.Embedded.Internals;
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace SurrealDb.Embedded.Internals;
 
 internal sealed class SurrealDbEmbeddedEngineConfig
 {
     public string? Ns { get; private set; }
     public string? Db { get; private set; }
 
-    public void Use(string ns, string? db)
+    public SurrealDbEmbeddedEngineConfig() { }
+
+    public SurrealDbEmbeddedEngineConfig(SurrealDbOptions options)
     {
-        Ns = ns;
-        Db = db;
+        Reset(options);
     }
 
-    public void Reset()
+    private void Reset(SurrealDbOptions options)
     {
-        Db = null;
+        Ns = options.Namespace;
+        Db = options.Database;
     }
 }

--- a/SurrealDb.Net.Tests/InsertRelationTests.cs
+++ b/SurrealDb.Net.Tests/InsertRelationTests.cs
@@ -1,10 +1,14 @@
-using System.Text;
+﻿using System.Text;
 using SurrealDb.Net.Exceptions;
 
 namespace SurrealDb.Net.Tests;
 
 public class InsertRelationTests
 {
+    /// <summary>
+    /// This test exists to do regression testing for this issue:
+    /// https://github.com/surrealdb/surrealdb.net/issues/151
+    /// </summary>
     [Theory]
     [InlineData("Endpoint=mem://")]
     [InlineData("Endpoint=rocksdb://")]

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
@@ -470,7 +470,9 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     public async Task<T> InsertRelation<T>(T data, CancellationToken cancellationToken)
         where T : RelationRecord
     {
-        if (_version?.Major < 2)
+        await EnsureVersionIsSetAsync(cancellationToken).ConfigureAwait(false);
+
+        if (_version is null || _version.Major < 2)
             throw new NotImplementedException();
 
         if (data.Id is null)
@@ -494,7 +496,9 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     )
         where T : RelationRecord
     {
-        if (_version?.Major < 2)
+        await EnsureVersionIsSetAsync(cancellationToken).ConfigureAwait(false);
+
+        if (_version is null || _version.Major < 2)
             throw new NotImplementedException();
 
         if (data.Id is not null)
@@ -873,7 +877,9 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         CancellationToken cancellationToken
     )
     {
-        if (_version?.Major < 2)
+        await EnsureVersionIsSetAsync(cancellationToken).ConfigureAwait(false);
+
+        if (_version is null || _version.Major < 2)
             throw new NotImplementedException();
 
         var dbResponse = await SendRequestAsync(
@@ -1025,7 +1031,9 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     public async Task<T> Update<T>(T data, CancellationToken cancellationToken)
         where T : Record
     {
-        if (_version?.Major < 2)
+        await EnsureVersionIsSetAsync(cancellationToken).ConfigureAwait(false);
+
+        if (_version is null || _version.Major < 2)
             throw new NotImplementedException();
 
         if (data.Id is null)
@@ -1048,7 +1056,9 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     )
         where TOutput : Record
     {
-        if (_version?.Major < 2)
+        await EnsureVersionIsSetAsync(cancellationToken).ConfigureAwait(false);
+
+        if (_version is null || _version.Major < 2)
             throw new NotImplementedException();
 
         var dbResponse = await SendRequestAsync(
@@ -1085,7 +1095,9 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     )
         where TOutput : Record
     {
-        if (_version?.Major < 2)
+        await EnsureVersionIsSetAsync(cancellationToken).ConfigureAwait(false);
+
+        if (_version is null || _version.Major < 2)
             throw new NotImplementedException();
 
         var dbResponse = await SendRequestAsync(
@@ -1103,6 +1115,8 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     {
         if (data.Id is null)
             throw new SurrealDbException("Cannot upsert a record without an Id");
+
+        await EnsureVersionIsSetAsync(cancellationToken).ConfigureAwait(false);
 
         string method = _version?.Major > 1 ? "upsert" : "update";
         var dbResponse = await SendRequestAsync(
@@ -1122,6 +1136,8 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     )
         where TOutput : Record
     {
+        await EnsureVersionIsSetAsync(cancellationToken).ConfigureAwait(false);
+
         string method = _version?.Major > 1 ? "upsert" : "update";
         var dbResponse = await SendRequestAsync(
                 method,
@@ -1140,6 +1156,8 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     )
         where T : class
     {
+        await EnsureVersionIsSetAsync(cancellationToken).ConfigureAwait(false);
+
         string method = _version?.Major > 1 ? "upsert" : "update";
         var dbResponse = await SendRequestAsync(
                 method,
@@ -1158,6 +1176,8 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
     )
         where TOutput : Record
     {
+        await EnsureVersionIsSetAsync(cancellationToken).ConfigureAwait(false);
+
         string method = _version?.Major > 1 ? "upsert" : "update";
         var dbResponse = await SendRequestAsync(
                 method,
@@ -1304,6 +1324,14 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
                 _semaphoreConnect.Release();
             }
         }
+    }
+
+    private async Task EnsureVersionIsSetAsync(CancellationToken cancellationToken)
+    {
+        if (_version is not null)
+            return;
+
+        await Version(cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<SurrealDbWsOkResponse> SendRequestAsync(

--- a/SurrealDb.Net/Internals/Ws/SurrealDbWsEngineConfig.cs
+++ b/SurrealDb.Net/Internals/Ws/SurrealDbWsEngineConfig.cs
@@ -35,7 +35,7 @@ internal class SurrealDbWsEngineConfig
         Auth = new NoAuth();
     }
 
-    public void Reset(SurrealDbOptions options)
+    private void Reset(SurrealDbOptions options)
     {
         Ns = options.Namespace;
         Db = options.Database;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Provide information on the motivation for why you have made this change.

## What does this change do?

Fixes issues:
* ensures version is set before using it in the WS engine, because it could `null` when executing an action without a previous `Connect`
* set predefined parameters for embedded engine, otherwise NS/DB configuration is never used

## What is your testing strategy?

Integration tests

## Is this related to any issues?

Fixes #151 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)