### PR TITLE
🐛 correctly call `AddSurreal` with parsed connection string

### DIFF
--- a/SurrealDb.Net/Extensions/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/SurrealDb.Net/Extensions/DependencyInjection/ServiceCollectionExtensions.cs
@@ -32,7 +32,11 @@ public static class ServiceCollectionExtensions
         Action<CborOptions>? configureCborOptions = null
     )
     {
-        return AddSurreal(services, connectionString, lifetime, configureCborOptions);
+        var configuration = SurrealDbOptions
+            .Create()
+            .FromConnectionString(connectionString)
+            .Build();
+        return AddSurreal(services, configuration, lifetime, configureCborOptions);
     }
 
     /// <summary>


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What does this change do?

Correctly consume the `AddSurreal` method, without calling itself...

## What is your testing strategy?

N/A

## Is this related to any issues?

Fix #188 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)