### PR TITLE
⚡️ make use of an `UnboundedPrioritizedChannel` to send ws message with priority

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,6 +31,7 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.0.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="System.Interactive.Async" Version="6.0.1" />
+    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="SystemTextJsonPatch" Version="4.0.0" />
     <PackageVersion Include="TUnit" Version="0.6.154" />
     <PackageVersion Include="Ulid" Version="1.3.3" />

--- a/SurrealDb.Embedded.Internals/SurrealDbEmbeddedEngine.cs
+++ b/SurrealDb.Embedded.Internals/SurrealDbEmbeddedEngine.cs
@@ -93,7 +93,9 @@ internal sealed partial class SurrealDbEmbeddedEngine : ISurrealDbProviderEngine
                 throw new SurrealDbException("Failed to retrieve serialized buffer.");
             }
 
-            var taskCompletionSource = new TaskCompletionSource<bool>();
+            var taskCompletionSource = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously
+            );
 
             Action<ByteBuffer> success = (_) =>
             {
@@ -274,7 +276,9 @@ internal sealed partial class SurrealDbEmbeddedEngine : ISurrealDbProviderEngine
             throw new SurrealDbException("Failed to retrieve serialized buffer.");
         }
 
-        var taskCompletionSource = new TaskCompletionSource<string>();
+        var taskCompletionSource = new TaskCompletionSource<string>(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
         timeoutCts.Token.Register(() =>
         {
             taskCompletionSource.TrySetCanceled();
@@ -369,7 +373,9 @@ internal sealed partial class SurrealDbEmbeddedEngine : ISurrealDbProviderEngine
         using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         cancellationToken.Register(timeoutCts.Cancel);
 
-        var taskCompletionSource = new TaskCompletionSource<Unit>();
+        var taskCompletionSource = new TaskCompletionSource<Unit>(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
         timeoutCts.Token.Register(() =>
         {
             taskCompletionSource.TrySetCanceled();
@@ -1053,7 +1059,9 @@ internal sealed partial class SurrealDbEmbeddedEngine : ISurrealDbProviderEngine
             throw new SurrealDbException("Failed to retrieve serialized buffer.");
         }
 
-        var taskCompletionSource = new TaskCompletionSource<T>();
+        var taskCompletionSource = new TaskCompletionSource<T>(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
         timeoutCts.Token.Register(() =>
         {
             taskCompletionSource.TrySetCanceled();

--- a/SurrealDb.Net.LiveQuery.Tests/ReactiveLiveQueryTests.Observe.cs
+++ b/SurrealDb.Net.LiveQuery.Tests/ReactiveLiveQueryTests.Observe.cs
@@ -21,7 +21,7 @@ public class ReactiveObserveLiveQueryTests : BaseLiveQueryTests
             await using var surrealDbClientGenerator = new SurrealDbClientGenerator();
             var dbInfo = surrealDbClientGenerator.GenerateDatabaseInfo();
 
-            await using var client = surrealDbClientGenerator.Create(connectionString);
+            var client = surrealDbClientGenerator.Create(connectionString);
             await client.SignIn(new RootAuth { Username = "root", Password = "root" });
             await client.Use(dbInfo.Namespace, dbInfo.Database);
 
@@ -47,24 +47,43 @@ public class ReactiveObserveLiveQueryTests : BaseLiveQueryTests
                 .OfType<SurrealDbLiveQueryOpenResponse>()
                 .Take(1)
                 .Select(_ =>
-                    Observable.FromAsync(async () =>
-                    {
-                        var record = await client.Create("test", new TestRecord { Value = 1 });
-                        await WaitLiveQueryNotificationAsync();
+                    Observable.FromAsync(
+                        async (cancellationToken) =>
+                        {
+                            var record = await client.Create(
+                                "test",
+                                new TestRecord { Value = 1 },
+                                cancellationToken
+                            );
+                            await WaitLiveQueryNotificationAsync();
 
-                        await client.Upsert(new TestRecord { Id = record.Id, Value = 2 });
-                        await WaitLiveQueryNotificationAsync();
+                            await client.Upsert(
+                                new TestRecord { Id = record.Id, Value = 2 },
+                                cancellationToken
+                            );
+                            await WaitLiveQueryNotificationAsync();
 
-                        await client.Delete(record.Id!);
-                        await WaitLiveQueryNotificationAsync();
-                    })
+                            await client.Delete(record.Id!, cancellationToken);
+                            await WaitLiveQueryNotificationAsync();
+                        }
+                    )
                 )
                 .Merge()
                 .SubscribeOn(testScheduler)
-                .Subscribe(_ =>
-                {
-                    completionSource.SetResult(true);
-                });
+                .Subscribe(
+                    _ =>
+                    {
+                        completionSource.SetResult(true);
+                    },
+                    e =>
+                    {
+                        e.Should().BeNull();
+                    },
+                    () =>
+                    {
+                        client.Dispose();
+                    }
+                );
 
             testScheduler.Start();
 
@@ -101,7 +120,7 @@ public class ReactiveObserveLiveQueryTests : BaseLiveQueryTests
             await using var surrealDbClientGenerator = new SurrealDbClientGenerator();
             var dbInfo = surrealDbClientGenerator.GenerateDatabaseInfo();
 
-            await using var client = surrealDbClientGenerator.Create(connectionString);
+            var client = surrealDbClientGenerator.Create(connectionString);
             await client.SignIn(new RootAuth { Username = "root", Password = "root" });
             await client.Use(dbInfo.Namespace, dbInfo.Database);
 
@@ -135,17 +154,26 @@ public class ReactiveObserveLiveQueryTests : BaseLiveQueryTests
                 .OfType<SurrealDbLiveQueryOpenResponse>()
                 .Take(1)
                 .Select(_ =>
-                    Observable.FromAsync(async () =>
-                    {
-                        var record = await client.Create("test", new TestRecord { Value = 1 });
-                        await WaitLiveQueryNotificationAsync();
+                    Observable.FromAsync(
+                        async (cancellationToken) =>
+                        {
+                            var record = await client.Create(
+                                "test",
+                                new TestRecord { Value = 1 },
+                                cancellationToken
+                            );
+                            await WaitLiveQueryNotificationAsync();
 
-                        await client.Upsert(new TestRecord { Id = record.Id, Value = 2 });
-                        await WaitLiveQueryNotificationAsync();
+                            await client.Upsert(
+                                new TestRecord { Id = record.Id, Value = 2 },
+                                cancellationToken
+                            );
+                            await WaitLiveQueryNotificationAsync();
 
-                        await client.Delete(record.Id!);
-                        await WaitLiveQueryNotificationAsync();
-                    })
+                            await client.Delete(record.Id!, cancellationToken);
+                            await WaitLiveQueryNotificationAsync();
+                        }
+                    )
                 )
                 .Merge()
                 .SubscribeOn(testScheduler)
@@ -157,6 +185,10 @@ public class ReactiveObserveLiveQueryTests : BaseLiveQueryTests
                     e =>
                     {
                         e.Should().BeNull();
+                    },
+                    () =>
+                    {
+                        client.Dispose();
                     }
                 );
 
@@ -195,7 +227,7 @@ public class ReactiveObserveLiveQueryTests : BaseLiveQueryTests
             await using var surrealDbClientGenerator = new SurrealDbClientGenerator();
             var dbInfo = surrealDbClientGenerator.GenerateDatabaseInfo();
 
-            await using var client = surrealDbClientGenerator.Create(connectionString);
+            var client = surrealDbClientGenerator.Create(connectionString);
             await client.SignIn(new RootAuth { Username = "root", Password = "root" });
             await client.Use(dbInfo.Namespace, dbInfo.Database);
 
@@ -226,17 +258,26 @@ public class ReactiveObserveLiveQueryTests : BaseLiveQueryTests
                 .OfType<SurrealDbLiveQueryOpenResponse>()
                 .Take(1)
                 .Select(_ =>
-                    Observable.FromAsync(async () =>
-                    {
-                        var record = await client.Create("test", new TestRecord { Value = 1 });
-                        await WaitLiveQueryNotificationAsync();
+                    Observable.FromAsync(
+                        async (cancellationToken) =>
+                        {
+                            var record = await client.Create(
+                                "test",
+                                new TestRecord { Value = 1 },
+                                cancellationToken
+                            );
+                            await WaitLiveQueryNotificationAsync();
 
-                        await client.Upsert(new TestRecord { Id = record.Id, Value = 2 });
-                        await WaitLiveQueryNotificationAsync();
+                            await client.Upsert(
+                                new TestRecord { Id = record.Id, Value = 2 },
+                                cancellationToken
+                            );
+                            await WaitLiveQueryNotificationAsync();
 
-                        await client.Delete(record.Id!);
-                        await WaitLiveQueryNotificationAsync();
-                    })
+                            await client.Delete(record.Id!, cancellationToken);
+                            await WaitLiveQueryNotificationAsync();
+                        }
+                    )
                 )
                 .Merge()
                 .SubscribeOn(testScheduler)
@@ -248,6 +289,10 @@ public class ReactiveObserveLiveQueryTests : BaseLiveQueryTests
                     e =>
                     {
                         e.Should().BeNull();
+                    },
+                    () =>
+                    {
+                        client.Dispose();
                     }
                 );
 

--- a/SurrealDb.Net/Exceptions/EmptySurrealDbResponseException.cs
+++ b/SurrealDb.Net/Exceptions/EmptySurrealDbResponseException.cs
@@ -3,7 +3,7 @@ namespace SurrealDb.Net.Exceptions;
 /// <summary>
 /// Generated exception when the response from the SurrealDb query is empty.
 /// </summary>
-public class EmptySurrealDbResponseException : Exception
+public sealed class EmptySurrealDbResponseException : SurrealDbException
 {
     internal EmptySurrealDbResponseException()
         : base("The response from the SurrealDb query was empty.") { }

--- a/SurrealDb.Net/Exceptions/EngineDisposedSurrealDbException.cs
+++ b/SurrealDb.Net/Exceptions/EngineDisposedSurrealDbException.cs
@@ -1,0 +1,7 @@
+﻿namespace SurrealDb.Net.Exceptions;
+
+public sealed class EngineDisposedSurrealDbException : SurrealDbException
+{
+    internal EngineDisposedSurrealDbException()
+        : base("The underlying engine of the SurrealDB client has been disposed.") { }
+}

--- a/SurrealDb.Net/Exceptions/MessageNotSentSurrealDbException.cs
+++ b/SurrealDb.Net/Exceptions/MessageNotSentSurrealDbException.cs
@@ -1,0 +1,7 @@
+﻿namespace SurrealDb.Net.Exceptions;
+
+public sealed class MessageNotSentSurrealDbException : SurrealDbException
+{
+    internal MessageNotSentSurrealDbException()
+        : base("Failed to send message.") { }
+}

--- a/SurrealDb.Net/Exceptions/SurrealDbErrorResultException.cs
+++ b/SurrealDb.Net/Exceptions/SurrealDbErrorResultException.cs
@@ -5,7 +5,7 @@ namespace SurrealDb.Net.Exceptions;
 /// <summary>
 /// Generated exception when the response from the SurrealDb query is an unexpected error.
 /// </summary>
-public class SurrealDbErrorResultException : Exception
+public class SurrealDbErrorResultException : SurrealDbException
 {
     public SurrealDbErrorResultException()
         : base(GetErrorMessage()) { }

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Net.WebSockets;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
+using ConcurrentCollections;
 using Dahomey.Cbor;
 using Microsoft.Extensions.DependencyInjection;
 using Semver;
@@ -44,10 +45,37 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         SurrealDbLiveQueryChannelSubscriptions
     > _liveQueryChannelSubscriptionsPerQuery = new();
     private readonly Pinger _pinger;
-    private readonly WsResponseTaskHandler _responseTaskHandler;
     private readonly SemaphoreSlim _semaphoreConnect = new(1, 1);
 
+#if NET9_0_OR_GREATER
+    private static readonly ConcurrentHashSet<string> _allResponseTaskIds = [];
+    private static readonly SurrealDbWsSendRequestChannel _sendRequestChannel = new();
+
+    private readonly ConcurrentDictionary<string, SurrealWsTaskCompletionSource> _responseTasks =
+        new();
+#else
+    private readonly WsResponseTaskHandler _responseTaskHandler;
+#endif
+
     private bool _isInitialized;
+
+#if NET9_0_OR_GREATER
+    static SurrealDbWsEngine()
+    {
+        // sender subscriptions
+        _sendRequestChannel
+            .ReadAllAsync()
+            .ToObservable()
+            .ObserveOn(TaskPoolScheduler.Default)
+            .Select(request =>
+                Observable.FromAsync(
+                    async () => await SendInnerRequestAsync(request).ConfigureAwait(false)
+                )
+            )
+            .Merge()
+            .Subscribe();
+    }
+#endif
 
     public SurrealDbWsEngine(
         SurrealDbOptions parameters,
@@ -84,7 +112,9 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
             ErrorReconnectTimeout = TimeSpan.FromSeconds(10),
         };
         _pinger = new(Ping);
+#if !NET9_0_OR_GREATER
         _responseTaskHandler = new(id);
+#endif
 
         _receiverSubscription = _wsClient
             .MessageReceived.ObserveOn(TaskPoolScheduler.Default)
@@ -135,10 +165,17 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 
                         if (
                             response is ISurrealDbWsStandardResponse surrealDbWsStandardResponse
+#if NET9_0_OR_GREATER
+                            && _responseTasks.TryRemove(
+                                surrealDbWsStandardResponse.Id,
+                                out var responseTaskCompletionSource
+                            )
+#else
                             && _responseTaskHandler.TryRemove(
                                 surrealDbWsStandardResponse.Id,
                                 out var responseTaskCompletionSource
                             )
+#endif
                         )
                         {
                             switch (response)
@@ -407,12 +444,20 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         await _wsClient.Stop(WebSocketCloseStatus.NormalClosure, "Client disposed");
         _receiverSubscription.Dispose();
 
+#if NET9_0_OR_GREATER
+        foreach (var (key, value) in _responseTasks)
+        {
+            _responseTasks.TryRemove(key, out _);
+            value.TrySetCanceled();
+        }
+
+#else
         foreach (var (key, value) in _responseTaskHandler)
         {
             _responseTaskHandler.TryRemove(key, out _);
             value.TrySetCanceled();
         }
-
+#endif
         _wsEngines.TryRemove(_id, out _);
 
         _wsClient.Dispose();
@@ -1399,7 +1444,16 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
             throw;
         }
 
-        var taskCompletionSource = new SurrealWsTaskCompletionSource(priority);
+#if NET9_0_OR_GREATER
+        var taskCompletionSource = new SurrealWsTaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+#else
+        var taskCompletionSource = new SurrealWsTaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously,
+            priority
+        );
+#endif
         timeoutCts.Token.Register(() =>
         {
             taskCompletionSource.TrySetCanceled();
@@ -1411,13 +1465,18 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         do
         {
             id = RandomHelper.CreateRandomId();
+#if NET9_0_OR_GREATER
+        } while (!_allResponseTaskIds.Add(id));
+        _responseTasks.TryAdd(id, taskCompletionSource);
+#else
         } while (!_responseTaskHandler.TryAdd(id, priority, taskCompletionSource));
+#endif
 
+#if !NET9_0_OR_GREATER
         await _responseTaskHandler.WaitUntilAsync(priority).ConfigureAwait(false);
-
+#endif
         bool shouldSendParamsInRequest = parameters is not null && parameters.Length > 0;
-
-        var request = new SurrealDbWsRequest
+        var innerRequest = new SurrealDbWsRequest
         {
             Id = id,
             Method = method,
@@ -1426,47 +1485,24 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 
         await using var stream = MemoryStreamProvider.MemoryStreamManager.GetStream();
 
-        try
-        {
-            await CborSerializer
-                .SerializeAsync(request, stream, GetCborOptions(), timeoutCts.Token)
-                .ConfigureAwait(false);
-        }
-        catch (OperationCanceledException)
-        {
-            timeoutCts.Dispose();
-
-            _responseTaskHandler.TryRemove(id, out _);
-            if (!cancellationToken.IsCancellationRequested)
-            {
-                _surrealDbLoggerFactory?.Method?.LogRequestFailed(id, "Timeout");
-                throw new TimeoutException();
-            }
-
-            throw;
-        }
-        catch
-        {
-            timeoutCts.Dispose();
-            _responseTaskHandler.TryRemove(id, out _);
-            throw;
-        }
-
-        bool canGetBuffer = stream.TryGetBuffer(out var payload);
-        bool isMessageSent = canGetBuffer && _wsClient.Send(payload);
-
-        if (!isMessageSent)
-        {
-            timeoutCts.Dispose();
-
-            _responseTaskHandler.TryRemove(id, out _);
-            taskCompletionSource.TrySetCanceled(CancellationToken.None);
-            _surrealDbLoggerFactory?.Method?.LogRequestFailed(id, "Failed to send message");
-            throw new SurrealDbException("Failed to send message");
-        }
+        var request = new SurrealDbWsSendRequest(
+            innerRequest,
+            priority,
+            taskCompletionSource,
+            stream,
+            new WeakReference<SurrealDbWsEngine>(this),
+            timeoutCts.Token
+        );
 
         try
         {
+#if NET9_0_OR_GREATER
+            await _sendRequestChannel.WriteAsync(request, timeoutCts.Token).ConfigureAwait(false);
+#else
+            await SendInnerRequestAsync(request).ConfigureAwait(false);
+#endif
+            var result = await taskCompletionSource.Task.ConfigureAwait(false);
+
 #if NET7_0_OR_GREATER
             var executionTime = Stopwatch.GetElapsedTime(executionStartTime);
 #else
@@ -1476,21 +1512,25 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 
             _surrealDbLoggerFactory?.Method?.LogRequestSuccess(
                 id,
-                method,
+                request.Content.Method,
                 SurrealDbLoggerExtensions.FormatRequestParameters(
-                    parameters!,
+                    request.Content.Parameters!,
                     _parameters.Logging.SensitiveDataLoggingEnabled
                 ),
                 SurrealDbLoggerExtensions.FormatExecutionTime(executionTime)
             );
 
-            return await taskCompletionSource.Task.ConfigureAwait(false);
+            return result;
+        }
+        catch (MessageNotSentSurrealDbException)
+        {
+            request.CompletionSource.TrySetCanceled(CancellationToken.None);
+            _surrealDbLoggerFactory?.Method?.LogRequestFailed(id, "Failed to send message");
+
+            throw;
         }
         catch (OperationCanceledException)
         {
-            timeoutCts.Dispose();
-
-            _responseTaskHandler.TryRemove(id, out _);
             if (!cancellationToken.IsCancellationRequested)
             {
                 _surrealDbLoggerFactory?.Method?.LogRequestFailed(id, "Timeout");
@@ -1499,11 +1539,49 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
 
             throw;
         }
-        catch
+        finally
         {
-            timeoutCts.Dispose();
+#if NET9_0_OR_GREATER
+            _responseTasks.TryRemove(id, out _);
+            _allResponseTaskIds.TryRemove(id);
+#else
             _responseTaskHandler.TryRemove(id, out _);
-            throw;
+#endif
+            timeoutCts.Dispose();
+        }
+    }
+
+    private static async Task SendInnerRequestAsync(SurrealDbWsSendRequest request)
+    {
+        if (!request.WsEngine.TryGetTarget(out var wsEngine))
+        {
+            request.CompletionSource.SetException(new EngineDisposedSurrealDbException());
+            return;
+        }
+
+        try
+        {
+            await CborSerializer
+                .SerializeAsync(
+                    request.Content,
+                    request.Stream,
+                    wsEngine.GetCborOptions(),
+                    request.CancellationToken
+                )
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            request.CompletionSource.SetException(ex);
+            return;
+        }
+
+        bool canGetBuffer = request.Stream.TryGetBuffer(out var payload);
+        bool isMessageSent = canGetBuffer && wsEngine._wsClient.Send(payload);
+
+        if (!isMessageSent)
+        {
+            request.CompletionSource.SetException(new MessageNotSentSurrealDbException());
         }
     }
 

--- a/SurrealDb.Net/Internals/Ws/SurrealDbWsRequest.cs
+++ b/SurrealDb.Net/Internals/Ws/SurrealDbWsRequest.cs
@@ -2,7 +2,7 @@
 
 namespace SurrealDb.Net.Internals.Ws;
 
-internal class SurrealDbWsRequest
+internal sealed class SurrealDbWsRequest
 {
     [CborProperty("id")]
     public string Id { get; set; } = string.Empty;

--- a/SurrealDb.Net/Internals/Ws/SurrealDbWsSendRequest.cs
+++ b/SurrealDb.Net/Internals/Ws/SurrealDbWsSendRequest.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.IO;
+
+namespace SurrealDb.Net.Internals.Ws;
+
+internal sealed class SurrealDbWsSendRequest
+{
+    public SurrealDbWsRequest Content { get; }
+    public SurrealDbWsRequestPriority Priority { get; }
+    public SurrealWsTaskCompletionSource CompletionSource { get; }
+    public RecyclableMemoryStream Stream { get; }
+    public WeakReference<SurrealDbWsEngine> WsEngine { get; }
+    public CancellationToken CancellationToken { get; }
+
+    public SurrealDbWsSendRequest(
+        SurrealDbWsRequest content,
+        SurrealDbWsRequestPriority priority,
+        SurrealWsTaskCompletionSource completionSource,
+        RecyclableMemoryStream stream,
+        WeakReference<SurrealDbWsEngine> wsEngine,
+        CancellationToken cancellationToken
+    )
+    {
+        Content = content;
+        Priority = priority;
+        CompletionSource = completionSource;
+        Stream = stream;
+        WsEngine = wsEngine;
+        CancellationToken = cancellationToken;
+    }
+}

--- a/SurrealDb.Net/Internals/Ws/SurrealDbWsSendRequestChannel.cs
+++ b/SurrealDb.Net/Internals/Ws/SurrealDbWsSendRequestChannel.cs
@@ -1,0 +1,37 @@
+﻿#if NET9_0_OR_GREATER
+using System.Threading.Channels;
+
+namespace SurrealDb.Net.Internals.Ws;
+
+internal sealed class SurrealDbWsSendRequestChannel
+{
+    private readonly Channel<SurrealDbWsSendRequest> _channel;
+
+    internal SurrealDbWsSendRequestChannel()
+    {
+        _channel = Channel.CreateUnboundedPrioritized(
+            new UnboundedPrioritizedChannelOptions<SurrealDbWsSendRequest>
+            {
+                Comparer = new SurrealDbWsSendRequestPriorityComparer(),
+            }
+        );
+    }
+
+    internal async Task WriteAsync(SurrealDbWsSendRequest item, CancellationToken cancellationToken)
+    {
+        await _channel.Writer.WriteAsync(item, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal IAsyncEnumerable<SurrealDbWsSendRequest> ReadAllAsync(
+        CancellationToken cancellationToken = default
+    )
+    {
+        return _channel.Reader.ReadAllAsync(cancellationToken);
+    }
+
+    internal void Complete()
+    {
+        _channel.Writer.Complete();
+    }
+}
+#endif

--- a/SurrealDb.Net/Internals/Ws/SurrealDbWsSendRequestPriorityComparer.cs
+++ b/SurrealDb.Net/Internals/Ws/SurrealDbWsSendRequestPriorityComparer.cs
@@ -1,0 +1,24 @@
+﻿namespace SurrealDb.Net.Internals.Ws;
+
+internal sealed class SurrealDbWsSendRequestPriorityComparer : IComparer<SurrealDbWsSendRequest>
+{
+    public int Compare(SurrealDbWsSendRequest? x, SurrealDbWsSendRequest? y)
+    {
+        if (x is null && y is null)
+        {
+            return 0;
+        }
+
+        if (x is null)
+        {
+            return -1;
+        }
+
+        if (y is null)
+        {
+            return 1;
+        }
+
+        return y.Priority.CompareTo(x.Priority);
+    }
+}

--- a/SurrealDb.Net/Internals/Ws/SurrealWsTaskCompletionSource.cs
+++ b/SurrealDb.Net/Internals/Ws/SurrealWsTaskCompletionSource.cs
@@ -1,11 +1,20 @@
 ﻿namespace SurrealDb.Net.Internals.Ws;
 
-internal class SurrealWsTaskCompletionSource : TaskCompletionSource<SurrealDbWsOkResponse>
+internal sealed class SurrealWsTaskCompletionSource : TaskCompletionSource<SurrealDbWsOkResponse>
 {
+#if NET9_0_OR_GREATER
+    public SurrealWsTaskCompletionSource(TaskCreationOptions options)
+        : base(options) { }
+#else
     public SurrealDbWsRequestPriority Priority { get; }
 
-    public SurrealWsTaskCompletionSource(SurrealDbWsRequestPriority priority)
+    public SurrealWsTaskCompletionSource(
+        TaskCreationOptions options,
+        SurrealDbWsRequestPriority priority
+    )
+        : base(options)
     {
         Priority = priority;
     }
+#endif
 }

--- a/SurrealDb.Net/Internals/Ws/WsResponseTaskHandler.cs
+++ b/SurrealDb.Net/Internals/Ws/WsResponseTaskHandler.cs
@@ -4,7 +4,7 @@ using ConcurrentCollections;
 
 namespace SurrealDb.Net.Internals.Ws;
 
-internal class WsResponseTaskHandler
+internal sealed class WsResponseTaskHandler
     : IEnumerable<KeyValuePair<string, SurrealWsTaskCompletionSource>>
 {
     private static readonly ConcurrentHashSet<string> _allResponseTaskIds = [];

--- a/SurrealDb.Net/SurrealDb.Net.csproj
+++ b/SurrealDb.Net/SurrealDb.Net.csproj
@@ -17,6 +17,7 @@
 	<PackageReference Include="Microsoft.Spatial" />
 	<PackageReference Include="Semver" />
 	<PackageReference Include="System.Collections.Immutable" />
+	<PackageReference Include="System.Linq.Async" />
 	<PackageReference Include="SystemTextJsonPatch" />
 	<PackageReference Include="Websocket.Client" />
   </ItemGroup>


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

N/A

## What does this change do?

* Make use of the new `UnboundedPrioritizedChannel` from .NET 9 to handle WS request to be sent based on their priority, instead of having to use a custom solution `WsResponseTaskHandler`.
* Should slightly reduce memory consumption (less data structures needed) and improve performance (less locks).
* Set `TaskCreationOptions` to ensure no "continuous locking" of thread.
* Code refactoring: avoid repetition of `catch` blocks in `SendRequestAsync` method

## What is your testing strategy?

Regression testing & benchmarks

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)