### PR TITLE
feat: add cbor serialization/deserialization logging

### DIFF
--- a/SurrealDb.Embedded.InMemory/SurrealDb.Embedded.InMemory.csproj
+++ b/SurrealDb.Embedded.InMemory/SurrealDb.Embedded.InMemory.csproj
@@ -28,6 +28,7 @@
     <Compile Include="..\SurrealDb.Net\Internals\Extensions\StringExtensions.cs" Link="Internals\Extensions\StringExtensions.cs" />
     <Compile Include="..\SurrealDb.Net\Internals\Extensions\SurrealDbLoggerExtensions.cs" Link="Internals\Extensions\SurrealDbLoggerExtensions.cs" />
     <Compile Include="..\SurrealDb.Net\Internals\Stream\MemoryStreamProvider.cs" Link="Internals\Stream\MemoryStreamProvider.cs" />
+    <Compile Include="..\SurrealDb.Net\Internals\Helpers\CborDebugHelper.cs" Link="Internals\Helpers\CborDebugHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -45,6 +46,7 @@
     <Folder Include="Internals\Extensions\" />
     <Folder Include="Internals\Constants\" />
     <Folder Include="Internals\Stream\" />
+    <Folder Include="Internals\Helpers\" />
     <Folder Include="Options\" />
   </ItemGroup>
 

--- a/SurrealDb.Embedded.Internals/SurrealDb.Embedded.Internals.csproj
+++ b/SurrealDb.Embedded.Internals/SurrealDb.Embedded.Internals.csproj
@@ -13,6 +13,7 @@
       <Compile Include="..\SurrealDb.Net\Internals\Extensions\StringExtensions.cs" Link="Internals\Extensions\StringExtensions.cs" />
       <Compile Include="..\SurrealDb.Net\Internals\Extensions\SurrealDbLoggerExtensions.cs" Link="Internals\Extensions\SurrealDbLoggerExtensions.cs" />
       <Compile Include="..\SurrealDb.Net\Internals\Stream\MemoryStreamProvider.cs" Link="Internals\Stream\MemoryStreamProvider.cs" />
+      <Compile Include="..\SurrealDb.Net\Internals\Helpers\CborDebugHelper.cs" Link="Internals\Helpers\CborDebugHelper.cs" />
     </ItemGroup>
 
     <ItemGroup>
@@ -24,6 +25,7 @@
       <Folder Include="Internals\Extensions\" />
       <Folder Include="Internals\Constants\" />
       <Folder Include="Internals\Stream\" />
+      <Folder Include="Internals\Helpers\" />
     </ItemGroup>
 
 </Project>

--- a/SurrealDb.Embedded.Internals/SurrealDbEmbeddedEngine.cs
+++ b/SurrealDb.Embedded.Internals/SurrealDbEmbeddedEngine.cs
@@ -3,6 +3,7 @@ using System.Reactive;
 using System.Runtime.InteropServices;
 using Dahomey.Cbor;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SurrealDb.Embedded.Options;
 using SurrealDb.Net.Exceptions;
@@ -10,6 +11,7 @@ using SurrealDb.Net.Extensions.DependencyInjection;
 using SurrealDb.Net.Internals;
 using SurrealDb.Net.Internals.Cbor;
 using SurrealDb.Net.Internals.Extensions;
+using SurrealDb.Net.Internals.Helpers;
 using SurrealDb.Net.Internals.Models.LiveQuery;
 using SurrealDb.Net.Internals.Stream;
 using SurrealDb.Net.Models;
@@ -87,6 +89,12 @@ internal sealed partial class SurrealDbEmbeddedEngine : ISurrealDbProviderEngine
                 .SerializeAsync(_options, stream, GetCborOptions(), cancellationToken)
                 .ConfigureAwait(false);
 
+            if (_surrealDbLoggerFactory?.Serialization?.IsEnabled(LogLevel.Debug) == true)
+            {
+                string cborData = CborDebugHelper.CborBinaryToHexa(stream);
+                _surrealDbLoggerFactory?.Serialization?.LogSerializationDataSerialized(cborData);
+            }
+
             bool canGetBuffer = stream.TryGetBuffer(out var bytes);
             if (!canGetBuffer)
             {
@@ -103,6 +111,14 @@ internal sealed partial class SurrealDbEmbeddedEngine : ISurrealDbProviderEngine
             };
             Action<ByteBuffer> fail = (byteBuffer) =>
             {
+                if (_surrealDbLoggerFactory?.Serialization?.IsEnabled(LogLevel.Debug) == true)
+                {
+                    string cborData = CborDebugHelper.CborBinaryToHexa(byteBuffer.AsReadOnly());
+                    _surrealDbLoggerFactory?.Serialization?.LogSerializationDataDeserialized(
+                        cborData
+                    );
+                }
+
                 string error = CborSerializer.Deserialize<string>(
                     byteBuffer.AsReadOnly(),
                     GetCborOptions()
@@ -270,6 +286,12 @@ internal sealed partial class SurrealDbEmbeddedEngine : ISurrealDbProviderEngine
             throw;
         }
 
+        if (_surrealDbLoggerFactory?.Serialization?.IsEnabled(LogLevel.Debug) == true)
+        {
+            string cborData = CborDebugHelper.CborBinaryToHexa(stream);
+            _surrealDbLoggerFactory?.Serialization?.LogSerializationDataSerialized(cborData);
+        }
+
         bool canGetBuffer = stream.TryGetBuffer(out var bytes);
         if (!canGetBuffer)
         {
@@ -286,6 +308,12 @@ internal sealed partial class SurrealDbEmbeddedEngine : ISurrealDbProviderEngine
 
         Action<ByteBuffer> success = (byteBuffer) =>
         {
+            if (_surrealDbLoggerFactory?.Serialization?.IsEnabled(LogLevel.Debug) == true)
+            {
+                string cborData = CborDebugHelper.CborBinaryToHexa(byteBuffer.AsReadOnly());
+                _surrealDbLoggerFactory?.Serialization?.LogSerializationDataDeserialized(cborData);
+            }
+
             try
             {
                 var result = CborSerializer.Deserialize<string>(
@@ -301,6 +329,12 @@ internal sealed partial class SurrealDbEmbeddedEngine : ISurrealDbProviderEngine
         };
         Action<ByteBuffer> fail = (byteBuffer) =>
         {
+            if (_surrealDbLoggerFactory?.Serialization?.IsEnabled(LogLevel.Debug) == true)
+            {
+                string cborData = CborDebugHelper.CborBinaryToHexa(byteBuffer.AsReadOnly());
+                _surrealDbLoggerFactory?.Serialization?.LogSerializationDataDeserialized(cborData);
+            }
+
             string error = CborSerializer.Deserialize<string>(
                 byteBuffer.AsReadOnly(),
                 GetCborOptions()
@@ -394,6 +428,12 @@ internal sealed partial class SurrealDbEmbeddedEngine : ISurrealDbProviderEngine
         };
         Action<ByteBuffer> fail = (byteBuffer) =>
         {
+            if (_surrealDbLoggerFactory?.Serialization?.IsEnabled(LogLevel.Debug) == true)
+            {
+                string cborData = CborDebugHelper.CborBinaryToHexa(byteBuffer.AsReadOnly());
+                _surrealDbLoggerFactory?.Serialization?.LogSerializationDataDeserialized(cborData);
+            }
+
             string error = CborSerializer.Deserialize<string>(
                 byteBuffer.AsReadOnly(),
                 GetCborOptions()
@@ -1049,6 +1089,12 @@ internal sealed partial class SurrealDbEmbeddedEngine : ISurrealDbProviderEngine
             throw;
         }
 
+        if (_surrealDbLoggerFactory?.Serialization?.IsEnabled(LogLevel.Debug) == true)
+        {
+            string cborData = CborDebugHelper.CborBinaryToHexa(stream);
+            _surrealDbLoggerFactory?.Serialization?.LogSerializationDataSerialized(cborData);
+        }
+
         bool canGetBuffer = stream.TryGetBuffer(out var bytes);
         if (!canGetBuffer)
         {
@@ -1073,6 +1119,14 @@ internal sealed partial class SurrealDbEmbeddedEngine : ISurrealDbProviderEngine
         {
             if (expectOutput)
             {
+                if (_surrealDbLoggerFactory?.Serialization?.IsEnabled(LogLevel.Debug) == true)
+                {
+                    string cborData = CborDebugHelper.CborBinaryToHexa(byteBuffer.AsReadOnly());
+                    _surrealDbLoggerFactory?.Serialization?.LogSerializationDataDeserialized(
+                        cborData
+                    );
+                }
+
                 try
                 {
                     var result = CborSerializer.Deserialize<T>(
@@ -1093,6 +1147,12 @@ internal sealed partial class SurrealDbEmbeddedEngine : ISurrealDbProviderEngine
         };
         Action<ByteBuffer> fail = (byteBuffer) =>
         {
+            if (_surrealDbLoggerFactory?.Serialization?.IsEnabled(LogLevel.Debug) == true)
+            {
+                string cborData = CborDebugHelper.CborBinaryToHexa(byteBuffer.AsReadOnly());
+                _surrealDbLoggerFactory?.Serialization?.LogSerializationDataDeserialized(cborData);
+            }
+
             string error = CborSerializer.Deserialize<string>(
                 byteBuffer.AsReadOnly(),
                 GetCborOptions()

--- a/SurrealDb.Embedded.RocksDb/SurrealDb.Embedded.RocksDb.csproj
+++ b/SurrealDb.Embedded.RocksDb/SurrealDb.Embedded.RocksDb.csproj
@@ -28,6 +28,7 @@
     <Compile Include="..\SurrealDb.Net\Internals\Extensions\StringExtensions.cs" Link="Internals\Extensions\StringExtensions.cs" />
     <Compile Include="..\SurrealDb.Net\Internals\Extensions\SurrealDbLoggerExtensions.cs" Link="Internals\Extensions\SurrealDbLoggerExtensions.cs" />
     <Compile Include="..\SurrealDb.Net\Internals\Stream\MemoryStreamProvider.cs" Link="Internals\Stream\MemoryStreamProvider.cs" />
+    <Compile Include="..\SurrealDb.Net\Internals\Helpers\CborDebugHelper.cs" Link="Internals\Helpers\CborDebugHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -45,6 +46,7 @@
     <Folder Include="Internals\Extensions\" />
     <Folder Include="Internals\Constants\" />
     <Folder Include="Internals\Stream\" />
+    <Folder Include="Internals\Helpers\" />
     <Folder Include="Options\" />
   </ItemGroup>
 

--- a/SurrealDb.Embedded.SurrealKv/SurrealDb.Embedded.SurrealKv.csproj
+++ b/SurrealDb.Embedded.SurrealKv/SurrealDb.Embedded.SurrealKv.csproj
@@ -28,6 +28,7 @@
     <Compile Include="..\SurrealDb.Net\Internals\Extensions\StringExtensions.cs" Link="Internals\Extensions\StringExtensions.cs" />
     <Compile Include="..\SurrealDb.Net\Internals\Extensions\SurrealDbLoggerExtensions.cs" Link="Internals\Extensions\SurrealDbLoggerExtensions.cs" />
     <Compile Include="..\SurrealDb.Net\Internals\Stream\MemoryStreamProvider.cs" Link="Internals\Stream\MemoryStreamProvider.cs" />
+    <Compile Include="..\SurrealDb.Net\Internals\Helpers\CborDebugHelper.cs" Link="Internals\Helpers\CborDebugHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -45,6 +46,7 @@
     <Folder Include="Internals\Extensions\" />
     <Folder Include="Internals\Constants\" />
     <Folder Include="Internals\Stream\" />
+    <Folder Include="Internals\Helpers\" />
     <Folder Include="Options\" />
   </ItemGroup>
 

--- a/SurrealDb.Net/Extensions/DependencyInjection/SurrealDbLoggerFactory.cs
+++ b/SurrealDb.Net/Extensions/DependencyInjection/SurrealDbLoggerFactory.cs
@@ -8,6 +8,7 @@ public interface ISurrealDbLoggerFactory
     ILogger? Connection { get; }
     ILogger? Method { get; }
     ILogger? Query { get; }
+    ILogger? Serialization { get; }
 }
 
 internal sealed class SurrealDbLoggerFactory : ISurrealDbLoggerFactory
@@ -15,11 +16,13 @@ internal sealed class SurrealDbLoggerFactory : ISurrealDbLoggerFactory
     public ILogger? Connection { get; }
     public ILogger? Method { get; }
     public ILogger? Query { get; }
+    public ILogger? Serialization { get; }
 
     public SurrealDbLoggerFactory(ILoggerFactory loggerFactory)
     {
         Connection = loggerFactory.CreateLogger(DbLoggerCategory.Connection.Name);
         Method = loggerFactory.CreateLogger(DbLoggerCategory.Method.Name);
         Query = loggerFactory.CreateLogger(DbLoggerCategory.Query.Name);
+        Serialization = loggerFactory.CreateLogger(DbLoggerCategory.Serialization.Name);
     }
 }

--- a/SurrealDb.Net/Internals/Extensions/SurrealDbLoggerExtensions.cs
+++ b/SurrealDb.Net/Internals/Extensions/SurrealDbLoggerExtensions.cs
@@ -98,6 +98,12 @@ internal static partial class SurrealDbLoggerExtensions
         string executionTime
     );
 
+    [LoggerMessage(Level = LogLevel.Debug, Message = "CBOR data serialized: {data}")]
+    public static partial void LogSerializationDataSerialized(this ILogger logger, string data);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "CBOR data deserialized: {data}")]
+    public static partial void LogSerializationDataDeserialized(this ILogger logger, string data);
+
     public static string FormatRequestParameters(
         object?[]? parameters,
         bool shouldLogParameterValues

--- a/SurrealDb.Net/Internals/Helpers/CborDebugHelper.cs
+++ b/SurrealDb.Net/Internals/Helpers/CborDebugHelper.cs
@@ -1,0 +1,39 @@
+﻿using System.Text;
+
+namespace SurrealDb.Net.Internals.Helpers;
+
+internal static class CborDebugHelper
+{
+    public static string CborBinaryToHexa(System.IO.Stream stream)
+    {
+        long previousPosition = stream.Position;
+
+        int index = 0;
+        var stringBuilder = new StringBuilder();
+
+        stream.Position = 0;
+
+        while (index < stream.Length)
+        {
+            int b = stream.ReadByte();
+            stringBuilder.AppendFormat("{0:x2}", b);
+            index++;
+        }
+
+        stream.Position = previousPosition;
+
+        return stringBuilder.ToString();
+    }
+
+    public static string CborBinaryToHexa(ReadOnlySpan<byte> bytes)
+    {
+        var stringBuilder = new StringBuilder(bytes.Length * 2);
+
+        foreach (byte b in bytes)
+        {
+            stringBuilder.AppendFormat("{0:x2}", b);
+        }
+
+        return stringBuilder.ToString();
+    }
+}

--- a/SurrealDb.Net/Internals/Logging/DbLoggerCategory.cs
+++ b/SurrealDb.Net/Internals/Logging/DbLoggerCategory.cs
@@ -35,4 +35,10 @@ internal static class DbLoggerCategory
     /// </summary>
 #endif
     public sealed class Query : LoggerCategory<Query>;
+
+    /// <summary>
+    /// Logger category for data serialization and deserialization,
+    /// e.g. hexa CBOR format exchanged between the client and a SurrealDB instance.
+    /// </summary>
+    public sealed class Serialization : LoggerCategory<Serialization>;
 }

--- a/SurrealDb.Net/SurrealDbClient.Methods.cs
+++ b/SurrealDb.Net/SurrealDbClient.Methods.cs
@@ -103,7 +103,8 @@ public abstract partial class BaseSurrealDbClient
         using var httpContent = SurrealDbHttpEngine.CreateBodyContent(
             null,
             wrapper.ConfigureCborOptions,
-            options ?? new()
+            options ?? new(),
+            null
         );
 
         bool shouldUsePostRequest =


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

@kearfy 

## What does this change do?

Add ability to log and read CBOR serialized/deserialized as hexa in order to better debug method calls.

* Support every engine (HTTP, WS, embedded)
* Log level set to `DEBUG` so it should not have any performance impact for production apps (unless debug or trace level is explicitly activated)

## What is your testing strategy?

Integration tests.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)