### PR TITLE
Create spans for create operations #12

### DIFF
--- a/SurrealDb.Net/Internals/SurrealDbEngine.Http.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Http.cs
@@ -1146,6 +1146,15 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
         CancellationToken cancellationToken
     )
     {
+        var activity = Activity.Current;
+
+        if (activity?.IsAllDataRequested == true)
+        {
+            activity.AddTag("network.protocol.name", "http");
+        }
+
+        try
+        {
         long executionStartTime = Stopwatch.GetTimestamp();
 
         if (_version == null && request.Method != "version")
@@ -1185,6 +1194,12 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
         );
 
         return surrealDbResponse;
+    }
+        catch (Exception)
+        {
+            //will enable additional tags to be added to the activity if desired
+            throw;
+        }
     }
 
     private async Task<SurrealDbHttpOkResponse> DeserializeDbResponseAsync(

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
@@ -1435,6 +1435,13 @@ internal class SurrealDbWsEngine : ISurrealDbEngine
         CancellationToken cancellationToken
     )
     {
+        var activity = Activity.Current;
+
+        if (activity?.IsAllDataRequested == true)
+        {
+            activity.AddTag("network.protocol.name", "ws");
+        }
+
         long executionStartTime = Stopwatch.GetTimestamp();
 
         using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));

--- a/SurrealDb.Net/SurrealDbClient.Methods.cs
+++ b/SurrealDb.Net/SurrealDbClient.Methods.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Text;
 using Semver;
 using SurrealDb.Net.Internals;
@@ -30,7 +31,20 @@ public abstract partial class BaseSurrealDbClient
     public Task<T> Create<T>(T data, CancellationToken cancellationToken = default)
         where T : IRecord
     {
-        return _engine.Create(data, cancellationToken);
+        var activity = SurrealTelemetry.StartActivity(Uri, "create");
+        try
+        {
+            return _engine.Create(data, cancellationToken);
+        }
+        catch (Exception exc)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, exc.Message);
+            throw;
+        }
+        finally
+        {
+            activity?.Stop();
+        }
     }
 
     public Task<T> Create<T>(
@@ -39,7 +53,20 @@ public abstract partial class BaseSurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return _engine.Create(table, data, cancellationToken);
+        var activity = SurrealTelemetry.StartActivity(Uri, "create", table);
+        try
+        {
+            return _engine.Create(table, data, cancellationToken);
+        }
+        catch (Exception exc)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, exc.Message);
+            throw;
+        }
+        finally
+        {
+            activity?.Stop();
+        }
     }
 
     public Task<TOutput> Create<TData, TOutput>(
@@ -49,7 +76,20 @@ public abstract partial class BaseSurrealDbClient
     )
         where TOutput : IRecord
     {
-        return _engine.Create<TData, TOutput>(recordId, data, cancellationToken);
+        var activity = SurrealTelemetry.StartActivity(Uri, "create");
+        try
+        {
+            return _engine.Create<TData, TOutput>(recordId, data, cancellationToken);
+        }
+        catch (Exception exc)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, exc.Message);
+            throw;
+        }
+        finally
+        {
+            activity?.Stop();
+        }
     }
 
     public Task Delete(string table, CancellationToken cancellationToken = default)

--- a/SurrealDb.Net/SurrealTelemetry.cs
+++ b/SurrealDb.Net/SurrealTelemetry.cs
@@ -1,0 +1,31 @@
+﻿using System.Diagnostics;
+
+namespace SurrealDb.Net
+{
+    internal static class SurrealTelemetry
+    {
+        internal const string ActivitySourceName = "SurrealDb.Net";
+        private static readonly ActivitySource activitySource = new ActivitySource(
+            ActivitySourceName
+        );
+
+        public static Activity? StartActivity(Uri uri, string operation, string? table = null)
+        {
+            var summary = string.IsNullOrEmpty(table) ? $"{operation};" : $"{operation} {table};";
+            var activity = activitySource.StartActivity(summary, ActivityKind.Client);
+            if (activity?.IsAllDataRequested == true)
+            {
+                activity.AddTag("server.address", uri.Host);
+                activity.AddTag("server.port", uri.Port);
+                activity.SetTag("db.system.name", "surrealdb");
+                activity.SetTag("db.operation.name", operation);
+                if (!string.IsNullOrEmpty(table))
+                {
+                    activity.SetTag("db.collection.name", table);
+                    activity.SetTag("db.query.summary", summary);
+                }
+            }
+            return activity;
+        }
+    }
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Start the Open Telemetry Journey for Surreal db which will enable better troubleshooting etc.

## What does this change do?

This wraps the create operations in Activities/Spans so that they can be analysed via OpenTelemetry.

## Is this related to any issues?

Progresses #12 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)?

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)