### PR TITLE
✨ add ability to pass system `AuthLevel` to connection string

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	  <IsAotCompatible>false</IsAotCompatible>
-    
+
     <IsPackable>false</IsPackable>
     <Version>0.9.0</Version>
     <Authors>surrealdb</Authors>
@@ -42,7 +42,7 @@
 	  <None Include="..\LICENSE" Pack="true" PackagePath="\" Visible="false" />
 	  <None Include="..\img\icon.png" Pack="true" PackagePath="\" Visible="false" />
   </ItemGroup>
-    
+
   <!-- Used to enable build & tests for embedded modes (memory, rocksdb, surrealkv) -->
   <PropertyGroup Label="Constants" Condition="true">
     <DefineConstants>EMBEDDED_MODE</DefineConstants>

--- a/SurrealDb.Net.Tests/DependencyInjection/SurrealDbOptionsBuilderTests.cs
+++ b/SurrealDb.Net.Tests/DependencyInjection/SurrealDbOptionsBuilderTests.cs
@@ -145,10 +145,36 @@ public class SurrealDbOptionsBuilderTests
     }
 
     [Test]
+    [Arguments("Root")]
+    [Arguments("Namespace")]
+    [Arguments("Database")]
+    public void ShouldCreateWithAuthLevel(string authLevel)
+    {
+        var options = new SurrealDbOptionsBuilder().WithAuthLevel(authLevel).Build();
+
+        options.Endpoint.Should().BeNull();
+        options.Namespace.Should().BeNull();
+        options.Database.Should().BeNull();
+        options.Username.Should().BeNull();
+        options.Password.Should().BeNull();
+        options.Token.Should().BeNull();
+        options.NamingPolicy.Should().BeNull();
+        options.AuthLevel.Should().Be(authLevel);
+    }
+
+    [Test]
+    public void ShouldFailToCreateWithIncorrectAuthLevel()
+    {
+        Action act = () => new SurrealDbOptionsBuilder().WithAuthLevel("test").Build();
+
+        act.Should().Throw<ArgumentException>().WithParameterName("authLevel");
+    }
+
+    [Test]
     public void ShouldCreateFromConnectionString()
     {
         string connectionString =
-            "Server=http://127.0.0.1:8000;Namespace=test;Database=test;Username=root;Password=root;NamingPolicy=CamelCase";
+            "Server=http://127.0.0.1:8000;Namespace=test;Database=test;Username=root;Password=root;NamingPolicy=CamelCase;AuthLevel=Namespace";
 
         var options = new SurrealDbOptionsBuilder().FromConnectionString(connectionString).Build();
 
@@ -159,6 +185,7 @@ public class SurrealDbOptionsBuilderTests
         options.Password.Should().Be("root");
         options.Token.Should().BeNull();
         options.NamingPolicy.Should().Be("CamelCase");
+        options.AuthLevel.Should().Be("Namespace");
     }
 
     [Test]

--- a/SurrealDb.Net/Extensions/DependencyInjection/SurrealDbOptions.cs
+++ b/SurrealDb.Net/Extensions/DependencyInjection/SurrealDbOptions.cs
@@ -1,5 +1,6 @@
 ﻿using SurrealDb.Net;
 using SurrealDb.Net.Extensions.DependencyInjection;
+using SurrealDb.Net.Internals.Auth;
 using SurrealDb.Net.Internals.Constants;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -47,6 +48,18 @@ public sealed class SurrealDbOptions
     public string? NamingPolicy { get; set; }
 
     /// <summary>
+    /// Auth level when connecting to the SurrealDB instance.
+    /// Valid options are "Root", "Namespace" or "Database".
+    /// Defaults to "Root".
+    /// </summary>
+    public string? AuthLevel { get; set; }
+
+    internal SystemAuthLevel SystemAuthLevel =>
+        string.IsNullOrWhiteSpace(AuthLevel)
+            ? SystemAuthLevel.Root
+            : Enum.Parse<SystemAuthLevel>(AuthLevel);
+
+    /// <summary>
     /// Indicates if the options are made to use a SurrealDB instance in embedded mode.
     /// Supported embedded modes are <c>mem://</c>, <c>rocksdb://</c> and <c>surrealkv://</c>.
     /// </summary>
@@ -71,6 +84,7 @@ public sealed class SurrealDbOptions
         Password = clone.Password;
         Token = clone.Token;
         NamingPolicy = clone.NamingPolicy;
+        AuthLevel = clone.AuthLevel;
         Logging = clone.Logging;
     }
 

--- a/SurrealDb.Net/Extensions/DependencyInjection/SurrealDbOptionsBuilder.cs
+++ b/SurrealDb.Net/Extensions/DependencyInjection/SurrealDbOptionsBuilder.cs
@@ -12,6 +12,7 @@ public sealed class SurrealDbOptionsBuilder
     private string? _password;
     private string? _token;
     private string? _namingPolicy;
+    private string? _authLevel;
     private bool _sensitiveDataLoggingEnabled;
 
     /// <summary>
@@ -215,6 +216,12 @@ public sealed class SurrealDbOptionsBuilder
                 EnsuresCorrectNamingPolicy(value, nameof(connectionString));
                 _namingPolicy = value;
             }
+            if (key.Equals("authLevel", StringComparison.OrdinalIgnoreCase))
+            {
+                string value = valueSpan.ToString();
+                EnsuresCorrectAuthLevel(value, nameof(connectionString));
+                _authLevel = value;
+            }
         }
 
         void ResetForNextIteration()
@@ -358,6 +365,29 @@ public sealed class SurrealDbOptionsBuilder
         throw new ArgumentException($"Invalid naming policy: {namingPolicy}", argumentName);
     }
 
+    public SurrealDbOptionsBuilder WithAuthLevel(string authLevel)
+    {
+        EnsuresCorrectAuthLevel(authLevel, nameof(authLevel));
+
+        _authLevel = authLevel;
+        return this;
+    }
+
+    private static void EnsuresCorrectAuthLevel(string authLevel, string argumentName)
+    {
+        if (string.IsNullOrWhiteSpace(authLevel))
+        {
+            return;
+        }
+
+        if (SurrealDbOptionsValidation.IsValidAuthLevel(authLevel))
+        {
+            return;
+        }
+
+        throw new ArgumentException($"Invalid auth level: {authLevel}", argumentName);
+    }
+
     /// <summary>
     /// Enables application data to be included in logs.
     /// This typically include parameter values set for SURQL queries, and parameters sent via any client methods.
@@ -384,6 +414,7 @@ public sealed class SurrealDbOptionsBuilder
             Password = _password,
             Token = _token,
             NamingPolicy = _namingPolicy,
+            AuthLevel = _authLevel,
             Logging = new() { SensitiveDataLoggingEnabled = _sensitiveDataLoggingEnabled },
         };
     }

--- a/SurrealDb.Net/Extensions/DependencyInjection/SurrealDbOptionsValidation.cs
+++ b/SurrealDb.Net/Extensions/DependencyInjection/SurrealDbOptionsValidation.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using SurrealDb.Net.Internals.Auth;
 using SurrealDb.Net.Internals.Constants;
 
 namespace SurrealDb.Net.Extensions.DependencyInjection;
@@ -89,5 +90,10 @@ internal sealed class SurrealDbOptionsValidation : IValidateOptions<SurrealDbOpt
         return validNamingPolicies.Any(vnp =>
             vnp.Equals(namingPolicy, StringComparison.OrdinalIgnoreCase)
         );
+    }
+
+    internal static bool IsValidAuthLevel(string authMode)
+    {
+        return Enum.TryParse<SystemAuthLevel>(authMode, out _);
     }
 }

--- a/SurrealDb.Net/Internals/Auth/Auth.Basic.cs
+++ b/SurrealDb.Net/Internals/Auth/Auth.Basic.cs
@@ -1,3 +1,0 @@
-namespace SurrealDb.Net.Internals.Auth;
-
-internal record BasicAuth(string Username, string? Password) : IAuth;

--- a/SurrealDb.Net/Internals/Auth/Auth.Interface.cs
+++ b/SurrealDb.Net/Internals/Auth/Auth.Interface.cs
@@ -1,3 +1,3 @@
 ﻿namespace SurrealDb.Net.Internals.Auth;
 
-internal interface IAuth { }
+internal interface IAuth;

--- a/SurrealDb.Net/Internals/Auth/Auth.System.cs
+++ b/SurrealDb.Net/Internals/Auth/Auth.System.cs
@@ -1,0 +1,5 @@
+using SurrealDb.Net.Models.Auth;
+
+namespace SurrealDb.Net.Internals.Auth;
+
+internal record InternalSystemAuth(SystemAuth Auth) : IAuth;

--- a/SurrealDb.Net/Internals/Auth/SystemAuthLevel.cs
+++ b/SurrealDb.Net/Internals/Auth/SystemAuthLevel.cs
@@ -1,0 +1,8 @@
+﻿namespace SurrealDb.Net.Internals.Auth;
+
+internal enum SystemAuthLevel
+{
+    Root,
+    Namespace,
+    Database,
+}

--- a/SurrealDb.Net/Internals/Extensions/SurrealDbLoggerExtensions.cs
+++ b/SurrealDb.Net/Internals/Extensions/SurrealDbLoggerExtensions.cs
@@ -41,6 +41,26 @@ internal static partial class SurrealDbLoggerExtensions
 
     [LoggerMessage(
         Level = LogLevel.Information,
+        Message = "Connection signed as namespace user, user={username}, password={password}."
+    )]
+    public static partial void LogConnectionSignedAsNamespaceUser(
+        this ILogger logger,
+        string username,
+        string password
+    );
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Connection signed as database user, user={username}, password={password}."
+    )]
+    public static partial void LogConnectionSignedAsDatabaseUser(
+        this ILogger logger,
+        string username,
+        string password
+    );
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
         Message = "Connection signed via token, token={token}."
     )]
     public static partial void LogConnectionSignedViaJwt(this ILogger logger, string token);

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Http.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Http.cs
@@ -665,7 +665,7 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
 
         await ExecuteRequestAsync(request, cancellationToken).ConfigureAwait(false);
 
-        _config.SetBasicAuth(rootAuth.Username, rootAuth.Password);
+        _config.SetSystemAuth(rootAuth);
     }
 
     public async Task<Jwt> SignIn(NamespaceAuth nsAuth, CancellationToken cancellationToken)
@@ -676,7 +676,7 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
             .ConfigureAwait(false);
         var token = dbResponse.GetValue<string>();
 
-        _config.SetBearerAuth(token!);
+        _config.SetSystemAuth(nsAuth);
 
         return new Jwt(token!);
     }
@@ -689,7 +689,7 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
             .ConfigureAwait(false);
         var token = dbResponse.GetValue<string>();
 
-        _config.SetBearerAuth(token!);
+        _config.SetSystemAuth(dbAuth);
 
         return new Jwt(token!);
     }
@@ -1053,10 +1053,12 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
                     bearerAuth.Token
                 );
                 break;
-            case BasicAuth basicAuth:
+            case InternalSystemAuth systemAuth:
             {
                 string credentials = Convert.ToBase64String(
-                    Encoding.ASCII.GetBytes($"{basicAuth.Username}:{basicAuth.Password}")
+                    Encoding.ASCII.GetBytes(
+                        $"{systemAuth.Auth.Username}:{systemAuth.Auth.Password}"
+                    )
                 );
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
                     AuthConstants.BASIC,

--- a/SurrealDb.Net/Models/Auth/DatabaseAuth.cs
+++ b/SurrealDb.Net/Models/Auth/DatabaseAuth.cs
@@ -5,7 +5,7 @@ namespace SurrealDb.Net.Models.Auth;
 /// <summary>
 /// Credentials for the database user
 /// </summary>
-public sealed class DatabaseAuth
+public sealed class DatabaseAuth : SystemAuth
 {
     /// <summary>
     /// The namespace the user has access to
@@ -18,16 +18,4 @@ public sealed class DatabaseAuth
     /// </summary>
     [CborProperty("db")]
     public string Database { get; set; } = string.Empty;
-
-    /// <summary>
-    /// The username of the namespace user
-    /// </summary>
-    [CborProperty("user")]
-    public string Username { get; set; } = string.Empty;
-
-    /// <summary>
-    /// The password of the namespace user
-    /// </summary>
-    [CborProperty("pass")]
-    public string Password { get; set; } = string.Empty;
 }

--- a/SurrealDb.Net/Models/Auth/NamespaceAuth.cs
+++ b/SurrealDb.Net/Models/Auth/NamespaceAuth.cs
@@ -5,23 +5,11 @@ namespace SurrealDb.Net.Models.Auth;
 /// <summary>
 /// Credentials for the namespace user
 /// </summary>
-public sealed class NamespaceAuth
+public sealed class NamespaceAuth : SystemAuth
 {
     /// <summary>
     /// The namespace the user has access to
     /// </summary>
     [CborProperty("ns")]
     public string Namespace { get; set; } = string.Empty;
-
-    /// <summary>
-    /// The username of the namespace user
-    /// </summary>
-    [CborProperty("user")]
-    public string Username { get; set; } = string.Empty;
-
-    /// <summary>
-    /// The password of the namespace user
-    /// </summary>
-    [CborProperty("pass")]
-    public string Password { get; set; } = string.Empty;
 }

--- a/SurrealDb.Net/Models/Auth/RootAuth.cs
+++ b/SurrealDb.Net/Models/Auth/RootAuth.cs
@@ -1,21 +1,6 @@
-﻿using Dahomey.Cbor.Attributes;
-
-namespace SurrealDb.Net.Models.Auth;
+﻿namespace SurrealDb.Net.Models.Auth;
 
 /// <summary>
 /// Credentials for the root user
 /// </summary>
-public sealed class RootAuth
-{
-    /// <summary>
-    /// The username of the root user
-    /// </summary>
-    [CborProperty("user")]
-    public string Username { get; set; } = string.Empty;
-
-    /// <summary>
-    /// The password of the root user
-    /// </summary>
-    [CborProperty("pass")]
-    public string Password { get; set; } = string.Empty;
-}
+public sealed class RootAuth : SystemAuth;

--- a/SurrealDb.Net/Models/Auth/SystemAuth.cs
+++ b/SurrealDb.Net/Models/Auth/SystemAuth.cs
@@ -1,0 +1,21 @@
+﻿using Dahomey.Cbor.Attributes;
+
+namespace SurrealDb.Net.Models.Auth;
+
+/// <summary>
+/// The base class for System authentication, either Root, Namespace or Database level.
+/// </summary>
+public abstract class SystemAuth
+{
+    /// <summary>
+    /// The username of the user
+    /// </summary>
+    [CborProperty("user")]
+    public string Username { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The password of the user
+    /// </summary>
+    [CborProperty("pass")]
+    public string Password { get; set; } = string.Empty;
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

N/A

## What does this change do?

Adds a new property system `AuthMode` to be used to automatically use the desired system auth mode, e.g. setting via connection string.

## What is your testing strategy?

Unit & integration tests

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)