### PR TITLE
✨ configure opentelemetry

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,13 +16,18 @@
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.2" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.1.0" />
     <PackageVersion Include="Microsoft.Spatial" Version="7.22.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.3.1" />
     <PackageVersion Include="MudBlazor" Version="6.11.2" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Api.ProviderBuilderExtensions" Version="1.15.0" />
     <PackageVersion Include="Pidgin" Version="3.2.3" />
     <PackageVersion Include="Scalar.AspNetCore" Version="1.2.36" />
     <PackageVersion Include="Semver" Version="3.0.0" />
@@ -34,6 +39,7 @@
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.1" />
     <PackageVersion Include="SystemTextJsonPatch" Version="4.2.0" />
+    <PackageVersion Include="ThisAssembly.Project" Version="2.1.2" />
     <PackageVersion Include="TUnit" Version="0.90.45" />
     <PackageVersion Include="Ulid" Version="1.4.1" />
     <PackageVersion Include="Verify.TUnit" Version="31.4.3" />

--- a/SurrealDb.Instrumentation/Internals/ExceptionExtensions.cs
+++ b/SurrealDb.Instrumentation/Internals/ExceptionExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System.Globalization;
+
+namespace SurrealDb.Instrumentation.Internals;
+
+internal static class ExceptionExtensions
+{
+    /// <summary>
+    /// Returns a culture-independent string representation of the given <paramref name="exception"/> object,
+    /// appropriate for diagnostics tracing.
+    /// </summary>
+    /// <param name="exception">Exception to convert to string.</param>
+    /// <returns>Exception as string with no culture.</returns>
+    public static string ToInvariantString(this Exception exception)
+    {
+        var originalUICulture = Thread.CurrentThread.CurrentUICulture;
+
+        try
+        {
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+            return exception.ToString();
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentUICulture = originalUICulture;
+        }
+    }
+}

--- a/SurrealDb.Instrumentation/Internals/InstrumentationHandleManager.cs
+++ b/SurrealDb.Instrumentation/Internals/InstrumentationHandleManager.cs
@@ -1,0 +1,71 @@
+﻿namespace SurrealDb.Instrumentation.Internals;
+
+internal sealed class InstrumentationHandleManager
+{
+    private int metricHandles;
+    private int tracingHandles;
+
+    /// <summary>
+    /// Gets the current count of active metric handles.
+    /// </summary>
+    public int MetricHandles => this.metricHandles;
+
+    /// <summary>
+    /// Gets the current count of active tracing handles.
+    /// </summary>
+    public int TracingHandles => this.tracingHandles;
+
+    /// <summary>
+    /// Adds a metric handle and returns an IDisposable to decrement the count when disposed.
+    /// </summary>
+    /// <returns>An IDisposable object.</returns>
+    public IDisposable AddMetricHandle() => new MetricHandle(this);
+
+    /// <summary>
+    /// Adds a tracing handle and returns an IDisposable to decrement the count when disposed.
+    /// </summary>
+    /// <returns>An IDisposable object.</returns>
+    public IDisposable AddTracingHandle() => new TracingHandle(this);
+
+    private sealed class MetricHandle : IDisposable
+    {
+        private readonly InstrumentationHandleManager manager;
+        private bool disposed;
+
+        public MetricHandle(InstrumentationHandleManager manager)
+        {
+            this.manager = manager;
+            Interlocked.Increment(ref this.manager.metricHandles);
+        }
+
+        public void Dispose()
+        {
+            if (!this.disposed)
+            {
+                Interlocked.Decrement(ref this.manager.metricHandles);
+                this.disposed = true;
+            }
+        }
+    }
+
+    private sealed class TracingHandle : IDisposable
+    {
+        private readonly InstrumentationHandleManager manager;
+        private bool disposed;
+
+        public TracingHandle(InstrumentationHandleManager manager)
+        {
+            this.manager = manager;
+            Interlocked.Increment(ref this.manager.tracingHandles);
+        }
+
+        public void Dispose()
+        {
+            if (!this.disposed)
+            {
+                Interlocked.Decrement(ref this.manager.tracingHandles);
+                this.disposed = true;
+            }
+        }
+    }
+}

--- a/SurrealDb.Instrumentation/Internals/SemanticConventions.cs
+++ b/SurrealDb.Instrumentation/Internals/SemanticConventions.cs
@@ -1,0 +1,37 @@
+﻿namespace SurrealDb.Instrumentation.Internals;
+
+internal static class SemanticConventions
+{
+    public const string AttributeRpcSystem = "rpc.system";
+    public const string AttributeRpcService = "rpc.service";
+    public const string AttributeRpcMethod = "rpc.method";
+    public const string AttributeRpcGrpcStatusCode = "rpc.grpc.status_code";
+
+    public const string AttributeExceptionEventName = "exception";
+    public const string AttributeExceptionType = "exception.type";
+    public const string AttributeExceptionMessage = "exception.message";
+    public const string AttributeExceptionStacktrace = "exception.stacktrace";
+    public const string AttributeErrorType = "error.type";
+
+    // v1.23.0
+    // https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/http/http-metrics.md#http-server
+    public const string AttributeClientAddress = "client.address";
+    public const string AttributeClientPort = "client.port";
+    public const string AttributeNetworkProtocolVersion = "network.protocol.version"; // replaces: "http.flavor" (AttributeHttpFlavor)
+    public const string AttributeNetworkProtocolName = "network.protocol.name";
+    public const string AttributeServerAddress = "server.address"; // replaces: "net.host.name" (AttributeNetHostName)
+    public const string AttributeServerPort = "server.port"; // replaces: "net.host.port" (AttributeNetHostPort)
+    public const string AttributeUserAgentOriginal = "user_agent.original"; // replaces: http.user_agent (AttributeHttpUserAgent)
+
+    // v1.36.0 database conventions:
+    // https://github.com/open-telemetry/semantic-conventions/tree/v1.36.0/docs/database
+    public const string AttributeDbCollectionName = "db.collection.name";
+    public const string AttributeDbOperationName = "db.operation.name";
+    public const string AttributeDbSystemName = "db.system.name";
+    public const string AttributeDbNamespace = "db.namespace";
+    public const string AttributeDbResponseStatusCode = "db.response.status_code";
+    public const string AttributeDbOperationBatchSize = "db.operation.batch.size";
+    public const string AttributeDbQuerySummary = "db.query.summary";
+    public const string AttributeDbQueryText = "db.query.text";
+    public const string AttributeDbStoredProcedureName = "db.stored_procedure.name";
+}

--- a/SurrealDb.Instrumentation/Internals/SurrealDbClientInstrumentation.cs
+++ b/SurrealDb.Instrumentation/Internals/SurrealDbClientInstrumentation.cs
@@ -1,0 +1,35 @@
+﻿using SurrealDb.Net.Telemetry;
+
+namespace SurrealDb.Instrumentation.Internals;
+
+internal sealed class SurrealDbClientInstrumentation : IDisposable
+{
+    public static readonly SurrealDbClientInstrumentation Instance = new();
+    public static SurrealDbClientTraceInstrumentationOptions TracingOptions { get; set; } = new();
+
+    public readonly InstrumentationHandleManager HandleManager = new();
+
+    private readonly SurrealDbEventHandler _handler = new();
+    private readonly Task _task;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SurrealDbClientInstrumentation"/> class.
+    /// </summary>
+    private SurrealDbClientInstrumentation()
+    {
+        _task = Task.Factory.StartNew(ProcessAsync, TaskCreationOptions.LongRunning);
+    }
+
+    private async Task ProcessAsync()
+    {
+        await foreach (var @event in SurrealDbTelemetryChannel.ReadAllAsync().ConfigureAwait(false))
+        {
+            _handler.HandleEvent(@event);
+        }
+    }
+
+    public void Dispose()
+    {
+        _task.Dispose();
+    }
+}

--- a/SurrealDb.Instrumentation/Internals/SurrealDbEventHandler.cs
+++ b/SurrealDb.Instrumentation/Internals/SurrealDbEventHandler.cs
@@ -1,0 +1,309 @@
+﻿using System.Diagnostics;
+using SurrealDb.Net.Telemetry.Events;
+
+namespace SurrealDb.Instrumentation.Internals;
+
+/// <summary>
+/// Does not support null Activity
+/// </summary>
+internal sealed class SurrealDbEventHandler
+{
+    public void HandleEvent(ISurrealDbTelemetryEvent @event)
+    {
+        if (
+            SurrealDbClientInstrumentation.Instance.HandleManager.TracingHandles == 0
+            && SurrealDbClientInstrumentation.Instance.HandleManager.MetricHandles == 0
+        )
+        {
+            return;
+        }
+
+        switch (@event)
+        {
+            case SurrealDbBeforeExecuteMethod payload:
+                HandleBeforeExecute(payload);
+                break;
+            case SurrealDbBeforeExecuteQuery payload:
+                HandleBeforeExecuteQuery(payload);
+                break;
+            case SurrealDbExecuteMethod payload:
+                HandleExecute(payload);
+                break;
+            case SurrealDbAfterExecuteMethod payload:
+                HandleAfterExecute(payload);
+                break;
+            case SurrealDbExecuteError payload:
+                HandleExecuteError(payload);
+                break;
+        }
+    }
+
+    private static void HandleBeforeExecute(object? payload)
+    {
+        const string name = SurrealDbBeforeExecuteMethod.Name;
+        if (payload is not SurrealDbBeforeExecuteMethod @event)
+        {
+            SurrealDbInstrumentationEventSource.Log.NullPayload(
+                nameof(SurrealDbEventHandler),
+                name
+            );
+            return;
+        }
+
+        var activity = SurrealDbTelemetryHelper.ActivitySource.StartActivity(
+            @event.Summary,
+            ActivityKind.Client,
+            default(ActivityContext)
+        );
+        var options = SurrealDbClientInstrumentation.TracingOptions;
+
+        if (activity is null)
+            return;
+
+        if (activity.IsAllDataRequested)
+        {
+            if (@event.Address is not null)
+            {
+                activity.AddTag(SemanticConventions.AttributeServerAddress, @event.Address.Host);
+                activity.AddTag(SemanticConventions.AttributeServerPort, @event.Address.Port);
+
+                var protocol = @event.Address.Scheme;
+                var networkProtocol = protocol switch
+                {
+                    "http" or "https" => "http",
+                    "ws" or "wss" => "ws",
+                    _ => null,
+                };
+
+                if (!string.IsNullOrEmpty(networkProtocol))
+                {
+                    activity.AddTag(
+                        SemanticConventions.AttributeNetworkProtocolName,
+                        networkProtocol
+                    );
+                }
+            }
+            activity.SetTag(
+                SemanticConventions.AttributeDbSystemName,
+                SurrealDbTelemetryHelper.SurrealDbSystemName
+            );
+            activity.SetTag(SemanticConventions.AttributeDbOperationName, @event.Method);
+
+            if (!string.IsNullOrEmpty(@event.Table))
+            {
+                activity.SetTag(SemanticConventions.AttributeDbCollectionName, @event.Table);
+                activity.SetTag(SemanticConventions.AttributeDbQuerySummary, @event.Summary);
+            }
+        }
+
+        if (activity.IsAllDataRequested)
+        {
+            try
+            {
+                if (options.Filter?.Invoke(@event) == false)
+                {
+                    SurrealDbInstrumentationEventSource.Log.MethodIsFilteredOut(
+                        activity.OperationName
+                    );
+                    activity.IsAllDataRequested = false;
+                    activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
+                }
+            }
+            catch (Exception ex)
+            {
+                SurrealDbInstrumentationEventSource.Log.MethodFilterException(ex);
+                activity.IsAllDataRequested = false;
+                activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
+            }
+        }
+    }
+
+    private static void HandleBeforeExecuteQuery(object? payload)
+    {
+        const string name = SurrealDbBeforeExecuteQuery.Name;
+        if (payload is not SurrealDbBeforeExecuteQuery @event)
+        {
+            SurrealDbInstrumentationEventSource.Log.NullPayload(
+                nameof(SurrealDbEventHandler),
+                name
+            );
+            return;
+        }
+
+        var activity = Activity.Current;
+        var options = SurrealDbClientInstrumentation.TracingOptions;
+
+        if (activity is null)
+        {
+            SurrealDbInstrumentationEventSource.Log.NullActivity(name);
+            return;
+        }
+
+        if (activity.Source != SurrealDbTelemetryHelper.ActivitySource)
+        {
+            return;
+        }
+
+        if (activity.IsAllDataRequested)
+        {
+            if (!string.IsNullOrEmpty(@event.Query))
+            {
+                activity.SetTag(SemanticConventions.AttributeDbQueryText, @event.Query);
+            }
+
+            if (options.SetDbQueryParameters && @event.Parameters is not null)
+            {
+                foreach (var parameter in @event.Parameters)
+                {
+                    activity.SetTag($"db.query.parameter.{parameter.Key}", parameter.Value);
+                }
+            }
+        }
+    }
+
+    private static void HandleExecute(object? payload)
+    {
+        const string name = SurrealDbExecuteMethod.Name;
+        if (payload is not SurrealDbExecuteMethod @event)
+        {
+            SurrealDbInstrumentationEventSource.Log.NullPayload(
+                nameof(SurrealDbEventHandler),
+                name
+            );
+            return;
+        }
+
+        var activity = Activity.Current;
+        var options = SurrealDbClientInstrumentation.TracingOptions;
+
+        if (activity is null)
+        {
+            SurrealDbInstrumentationEventSource.Log.NullActivity(name);
+            return;
+        }
+
+        if (activity.Source != SurrealDbTelemetryHelper.ActivitySource)
+        {
+            return;
+        }
+
+        if (activity.IsAllDataRequested)
+        {
+            string? dbNamespace = null;
+            if (!string.IsNullOrEmpty(@event.Namespace))
+            {
+                dbNamespace = @event.Namespace;
+                if (!string.IsNullOrEmpty(@event.Database))
+                {
+                    dbNamespace += '|' + @event.Database;
+                }
+            }
+
+            if (!string.IsNullOrEmpty(dbNamespace))
+            {
+                activity.AddTag(SemanticConventions.AttributeDbNamespace, dbNamespace);
+            }
+        }
+
+        if (options.EnableTraceContextPropagation && @event.Data is not null)
+        {
+            var tracedflags =
+                (activity.ActivityTraceFlags & ActivityTraceFlags.Recorded) != 0 ? "01" : "00";
+            @event.Data.Traceparent =
+                $"00-{activity.TraceId.ToHexString()}-{activity.SpanId.ToHexString()}-{tracedflags}";
+        }
+    }
+
+    private static void HandleAfterExecute(object? payload)
+    {
+        const string name = SurrealDbAfterExecuteMethod.Name;
+        if (payload is not SurrealDbAfterExecuteMethod @event)
+        {
+            SurrealDbInstrumentationEventSource.Log.NullPayload(
+                nameof(SurrealDbEventHandler),
+                name
+            );
+            return;
+        }
+
+        var activity = Activity.Current;
+        if (activity is null)
+        {
+            SurrealDbInstrumentationEventSource.Log.NullActivity(name);
+            return;
+        }
+
+        if (activity.Source != SurrealDbTelemetryHelper.ActivitySource)
+        {
+            return;
+        }
+
+        if (activity.IsAllDataRequested && @event.BatchSize is > 1)
+        {
+            activity.AddTag(
+                SemanticConventions.AttributeDbOperationBatchSize,
+                @event.BatchSize.Value
+            );
+        }
+
+        activity.Stop();
+        RecordDuration(activity);
+    }
+
+    private static void HandleExecuteError(object? payload)
+    {
+        const string name = SurrealDbExecuteError.Name;
+        if (payload is not SurrealDbExecuteError @event)
+        {
+            SurrealDbInstrumentationEventSource.Log.NullPayload(
+                nameof(SurrealDbEventHandler),
+                name
+            );
+            return;
+        }
+
+        var activity = Activity.Current;
+        var options = SurrealDbClientInstrumentation.TracingOptions;
+
+        if (activity is null)
+        {
+            SurrealDbInstrumentationEventSource.Log.NullActivity(name);
+            return;
+        }
+
+        if (activity.Source != SurrealDbTelemetryHelper.ActivitySource)
+        {
+            return;
+        }
+
+        if (activity.IsAllDataRequested && @event.Exception is not null)
+        {
+            activity.AddTag(
+                SemanticConventions.AttributeErrorType,
+                @event.Exception.GetType().FullName
+            );
+            activity.SetStatus(ActivityStatusCode.Error, @event.Exception.Message);
+
+            if (options.RecordException)
+            {
+                activity.AddException(@event.Exception);
+            }
+        }
+
+        activity.Stop();
+        RecordDuration(activity);
+    }
+
+    private static void RecordDuration(Activity activity)
+    {
+        if (SurrealDbClientInstrumentation.Instance.HandleManager.MetricHandles == 0)
+        {
+            return;
+        }
+
+        var tags = default(TagList);
+
+        var duration = activity.Duration.TotalSeconds;
+        SurrealDbTelemetryHelper.DbClientOperationDuration.Record(duration, tags);
+    }
+}

--- a/SurrealDb.Instrumentation/Internals/SurrealDbInstrumentationEventSource.cs
+++ b/SurrealDb.Instrumentation/Internals/SurrealDbInstrumentationEventSource.cs
@@ -1,0 +1,98 @@
+﻿using System.Diagnostics.Tracing;
+
+namespace SurrealDb.Instrumentation.Internals;
+
+internal interface IConfigurationExtensionsLogger
+{
+    void LogInvalidConfigurationValue(string key, string value);
+}
+
+/// <summary>
+/// EventSource events emitted from the project.
+/// </summary>
+[EventSource(Name = "OpenTelemetry-Instrumentation-SurrealDbClient")]
+internal sealed class SurrealDbInstrumentationEventSource
+    : EventSource,
+        IConfigurationExtensionsLogger
+{
+    public static readonly SurrealDbInstrumentationEventSource Log = new();
+
+    [NonEvent]
+    public void UnknownErrorProcessingEvent(string handlerName, string eventName, Exception ex)
+    {
+        if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
+        {
+            this.UnknownErrorProcessingEvent(handlerName, eventName, ex.ToInvariantString());
+        }
+    }
+
+    [Event(
+        1,
+        Message = "Unknown error processing event '{1}' from handler '{0}', Exception: {2}",
+        Level = EventLevel.Error
+    )]
+    public void UnknownErrorProcessingEvent(string handlerName, string eventName, string ex)
+    {
+        this.WriteEvent(1, handlerName, eventName, ex);
+    }
+
+    [Event(
+        2,
+        Message = "Current Activity is NULL in the '{0}' callback. Span will not be recorded.",
+        Level = EventLevel.Warning
+    )]
+    public void NullActivity(string eventName)
+    {
+        this.WriteEvent(2, eventName);
+    }
+
+    [Event(
+        3,
+        Message = "Payload is NULL in event '{1}' from handler '{0}', span will not be recorded.",
+        Level = EventLevel.Warning
+    )]
+    public void NullPayload(string handlerName, string eventName)
+    {
+        this.WriteEvent(3, handlerName, eventName);
+    }
+
+    [Event(6, Message = "Method is filtered out. Activity {0}", Level = EventLevel.Verbose)]
+    public void MethodIsFilteredOut(string activityName)
+    {
+        this.WriteEvent(6, activityName);
+    }
+
+    [NonEvent]
+    public void MethodFilterException(Exception ex)
+    {
+        if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
+        {
+            this.MethodFilterException(ex.ToInvariantString());
+        }
+    }
+
+    [Event(
+        7,
+        Message = "Method filter threw exception. Method will not be collected. Exception {0}.",
+        Level = EventLevel.Error
+    )]
+    public void MethodFilterException(string exception)
+    {
+        this.WriteEvent(7, exception);
+    }
+
+    [Event(
+        8,
+        Message = "Configuration key '{0}' has an invalid value: '{1}'",
+        Level = EventLevel.Warning
+    )]
+    public void InvalidConfigurationValue(string key, string value)
+    {
+        this.WriteEvent(8, key, value);
+    }
+
+    public void LogInvalidConfigurationValue(string key, string value)
+    {
+        this.InvalidConfigurationValue(key, value);
+    }
+}

--- a/SurrealDb.Instrumentation/Internals/SurrealDbTelemetryHelper.cs
+++ b/SurrealDb.Instrumentation/Internals/SurrealDbTelemetryHelper.cs
@@ -1,0 +1,51 @@
+﻿using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace SurrealDb.Instrumentation.Internals;
+
+internal static class SurrealDbTelemetryHelper
+{
+    public const string SurrealDbSystemName = "surrealdb";
+
+    private static readonly (ActivitySource ActivitySource, Meter Meter) Telemetry =
+        CreateTelemetry();
+    public static readonly ActivitySource ActivitySource = Telemetry.ActivitySource;
+    public static readonly Meter Meter = Telemetry.Meter;
+
+    public static readonly Histogram<double> DbClientOperationDuration = Meter.CreateHistogram(
+        "db.client.operation.duration",
+        unit: "s",
+        description: "Duration of database client operations.",
+        advice: new InstrumentAdvice<double>
+        {
+            HistogramBucketBoundaries = [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10],
+        }
+    );
+
+    private static (ActivitySource ActivitySource, Meter Meter) CreateTelemetry()
+    {
+        const string telemetrySchemaUrl = "https://opentelemetry.io/schemas/1.33.0";
+        const string version = ThisAssembly.Project.Version;
+
+        var activitySourceOptions = new ActivitySourceOptions(ActivitySourceName)
+        {
+            Version = version,
+            TelemetrySchemaUrl = telemetrySchemaUrl,
+        };
+
+        var meterOptions = new MeterOptions(ActivitySourceName)
+        {
+            Version = version,
+            TelemetrySchemaUrl = telemetrySchemaUrl,
+        };
+
+        return (new ActivitySource(activitySourceOptions), new Meter(meterOptions));
+    }
+
+    public const string ActivitySourceName = ThisAssembly.Project.AssemblyName;
+
+    public static Activity? StartActivity(string summary)
+    {
+        return ActivitySource.StartActivity(summary, ActivityKind.Client);
+    }
+}

--- a/SurrealDb.Instrumentation/README.md
+++ b/SurrealDb.Instrumentation/README.md
@@ -1,0 +1,217 @@
+# SurrealDB Instrumentation for OpenTelemetry
+
+This is an [Instrumentation
+Library](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/glossary.md#instrumentation-library),
+which instruments and collects traces about database operations.
+
+This component is based on
+[v1.33](https://github.com/open-telemetry/semantic-conventions/blob/v1.33.0/docs/database/README.md)
+of database semantic conventions. For details on the default set of
+attributes that are added, check out the [Traces](#traces) and
+[Metrics](#metrics) sections below.
+
+## Steps to enable SurrealDb.Instrumentation
+
+### Step 1: Install Package
+
+Add a reference to the
+[`SurrealDb.Instrumentation`](https://www.nuget.org/packages/SurrealDb.Instrumentation)
+package. Also, add any other instrumentations & exporters you will need.
+
+```shell
+dotnet add package SurrealDb.Instrumentation
+```
+
+### Step 2: Enable SurrealDB Instrumentation at application startup
+
+SurrealDB instrumentation must be enabled at application startup.
+
+#### Traces
+
+The following example demonstrates adding SurrealDB traces instrumentation
+to a console application. This example also sets up the OpenTelemetry Console
+exporter, which requires adding the package
+[`OpenTelemetry.Exporter.Console`](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Exporter.Console/README.md)
+to the application.
+
+```csharp
+using OpenTelemetry.Trace;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSurrealDbClientInstrumentation()
+            .AddConsoleExporter()
+            .Build();
+    }
+}
+```
+
+The instrumentation adheres to the
+[semantic conventions for database client spans][semconv-spans].
+An activity emitted by the instrumentation will include the following list of
+attributes:
+
+* `error.type`
+* `db.namespace`
+* `db.operation.name`
+* `db.query.summary`
+* `db.query.text`
+* `db.system.name`
+* `server.address`
+* `server.port`
+
+#### Metrics
+
+The following example demonstrates adding SurrealDB metrics instrumentation
+to a console application. This example also sets up the OpenTelemetry Console
+exporter, which requires adding the package
+[`OpenTelemetry.Exporter.Console`](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Exporter.Console/README.md)
+to the application.
+
+```csharp
+using OpenTelemetry.Metrics;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddSurrealDbClientInstrumentation()
+            .AddConsoleExporter()
+            .Build();
+    }
+}
+```
+
+The instrumentation adheres to the
+[semantic conventions for database client metrics][semconv-metrics].
+
+Currently, the instrumentation supports the following metric and attributes.
+
+| Name | Instrument Type | Unit | Description |
+| ---- | --------------- | ---- | ----------- |
+| `db.client.operation.duration` | Histogram | `s` | Duration of database client operations. |
+
+* `error.type`
+* `db.namespace`
+* `db.operation.name`
+* `db.query.summary`
+* `db.system.name`
+* `server.address`
+* `server.port`
+
+#### ASP.NET Core
+
+For an ASP.NET Core application, adding instrumentation is typically done in the
+`ConfigureServices` of your `Startup` class. Refer to documentation for
+[OpenTelemetry.Instrumentation.AspNetCore](../OpenTelemetry.Instrumentation.AspNetCore/README.md).
+
+#### ASP.NET
+
+For an ASP.NET application, adding instrumentation is typically done in the
+`Global.asax.cs`. Refer to the documentation for
+[OpenTelemetry.Instrumentation.AspNet](../OpenTelemetry.Instrumentation.AspNet/README.md).
+
+## Advanced configuration
+
+This instrumentation can be configured to change the default behavior by using
+`SurrealDbClientTraceInstrumentationOptions`.
+
+### RecordException
+
+This option can be set to instruct the instrumentation to record Exceptions
+as Activity
+[events](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/exceptions/exceptions-spans.md).
+
+The default value is `false` and can be changed by the code like below.
+
+```csharp
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .AddSurrealDbClientInstrumentation(
+        options => options.RecordException = true)
+    .AddConsoleExporter()
+    .Build();
+```
+
+### Filter
+
+This option can be used to filter out activities based on the properties of the
+`SurrealDbBeforeExecuteMethod` telemetry event being instrumented using a `Func<SurrealDbBeforeExecuteMethod, bool>`. The
+function receives an instance of the `SurrealDbBeforeExecuteMethod` event and should return `true`
+if the telemetry is to be collected, and `false` if it should not. The example below filters out all query methods.
+
+```csharp
+using var traceProvider = Sdk.CreateTracerProviderBuilder()
+   .AddSqlClientInstrumentation(
+       opt =>
+       {
+           opt.Filter = @event =>
+           {
+               return @event.Method != "query";
+           };
+       })
+   .AddConsoleExporter()
+   .Build();
+```
+
+## Experimental features
+
+> [!NOTE]
+> Experimental features are not enabled by default and can only be activated with
+> environment variables. They are subject to change or removal in future releases.
+
+### DB query parameters
+
+The `OTEL_DOTNET_EXPERIMENTAL_SURREALDB_CLIENT_ENABLE_TRACE_DB_QUERY_PARAMETERS` environment
+variable controls whether `db.query.parameter.<key>` attributes are emitted.
+
+Query parameters may contain sensitive data, so only enable this experimental feature
+if your queries and/or environment are appropriate for enabling this option.
+
+`OTEL_DOTNET_EXPERIMENTAL_SURREALDB_CLIENT_ENABLE_TRACE_DB_QUERY_PARAMETERS` is implicitly
+`false` by default. When set to `true`, the instrumentation will set
+[`db.query.parameter.<key>`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#span-definition)
+attributes for each of the query parameters associated with a database command.
+
+### Trace Context Propagation
+
+Database trace context propagation can be enabled by setting
+`OTEL_DOTNET_EXPERIMENTAL_SURREALDB_CLIENT_ENABLE_TRACE_CONTEXT_PROPAGATION`
+environment variable to `true`.
+This uses the [traceparent](https://www.w3.org/TR/trace-context/#traceparent-header)
+information for the current connection.
+
+## Activity Duration calculation
+
+`Activity.Duration` represents the time the underlying connection takes to
+execute the method/query. Completing the operation includes the time up to
+determining that the request was successful. It doesn't include the time spent
+reading the results from a query set (for example enumerating all the rows
+returned by a data reader).
+
+This is illustrated by the code snippet below:
+
+```csharp
+using var client = new SurrealDbConnection("...");
+
+// Activity duration starts
+var response = await client.Query("...");
+// Activity duration ends
+
+// Not included in the Activity duration
+foreach (var result in response)
+{
+}
+```
+
+## References
+
+* [OpenTelemetry Project](https://opentelemetry.io/)
+* [Semantic conventions for database client spans][semconv-spans]
+* [Semantic conventions for database client metrics][semconv-metrics]
+
+[semconv-metrics]: https://github.com/open-telemetry/semantic-conventions/blob/v1.33.0/docs/database/database-metrics.md
+[semconv-spans]: https://github.com/open-telemetry/semantic-conventions/blob/v1.33.0/docs/database/database-spans.md

--- a/SurrealDb.Instrumentation/SurrealDb.Instrumentation.csproj
+++ b/SurrealDb.Instrumentation/SurrealDb.Instrumentation.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+      <TargetFrameworks>netstandard2.1;net8.0;net9.0;net10.0</TargetFrameworks>
+
+      <IsPackable>true</IsPackable>
+      <PackageId>SurrealDb.Instrumentation</PackageId>
+      <Description>OpenTelemetry instrumentation for the SurrealDB library for .NET</Description>
+      <PackageTags>SurrealDB Surreal Database OpenTelemetry</PackageTags>
+    </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="OpenTelemetry.Api" />
+    <PackageReference Include="OpenTelemetry.Api.ProviderBuilderExtensions" />
+    <PackageReference Include="ThisAssembly.Project">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectProperty Include="PackageId" />
+    <ProjectProperty Include="Version" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SurrealDb.Net\SurrealDb.Net.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SurrealDb.Instrumentation/SurrealDbClientMeterProviderBuilderExtensions.cs
+++ b/SurrealDb.Instrumentation/SurrealDbClientMeterProviderBuilderExtensions.cs
@@ -1,0 +1,28 @@
+﻿using SurrealDb.Instrumentation.Internals;
+
+namespace OpenTelemetry.Metrics;
+
+/// <summary>
+/// Extension methods to simplify registering of dependency instrumentation.
+/// </summary>
+public static class SurrealDbClientMeterProviderBuilderExtensions
+{
+    /// <summary>
+    /// Enables SurrealDbClient instrumentation.
+    /// </summary>
+    /// <param name="builder"><see cref="MeterProviderBuilder"/> being configured.</param>
+    /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
+    public static MeterProviderBuilder AddSurrealDbClientInstrumentation(
+        this MeterProviderBuilder builder
+    )
+    {
+        builder.AddInstrumentation(sp =>
+        {
+            return SurrealDbClientInstrumentation.Instance.HandleManager.AddMetricHandle();
+        });
+
+        builder.AddMeter(SurrealDbTelemetryHelper.Meter.Name);
+
+        return builder;
+    }
+}

--- a/SurrealDb.Instrumentation/SurrealDbClientTraceInstrumentationOptions.cs
+++ b/SurrealDb.Instrumentation/SurrealDbClientTraceInstrumentationOptions.cs
@@ -1,0 +1,106 @@
+﻿using System.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using SurrealDb.Instrumentation.Internals;
+using SurrealDb.Net.Telemetry.Events;
+
+namespace SurrealDb.Instrumentation;
+
+/// <summary>
+/// Options for <see cref="SurrealDbClientInstrumentation"/>.
+/// </summary>
+public class SurrealDbClientTraceInstrumentationOptions
+{
+    private const string ContextPropagationLevelEnvVar =
+        "OTEL_DOTNET_EXPERIMENTAL_SURREALDB_CLIENT_ENABLE_TRACE_CONTEXT_PROPAGATION";
+    private const string SetDbQueryParametersEnvVar =
+        "OTEL_DOTNET_EXPERIMENTAL_SURREALDB_CLIENT_ENABLE_TRACE_DB_QUERY_PARAMETERS";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SurrealDbClientTraceInstrumentationOptions"/> class.
+    /// </summary>
+    public SurrealDbClientTraceInstrumentationOptions()
+        : this(new ConfigurationBuilder().AddEnvironmentVariables().Build()) { }
+
+    private SurrealDbClientTraceInstrumentationOptions(IConfiguration configuration)
+    {
+        if (
+            bool.TryParse(
+                configuration[ContextPropagationLevelEnvVar],
+                out bool enableTraceContextPropagationValue
+            )
+        )
+        {
+            this.EnableTraceContextPropagation = enableTraceContextPropagationValue;
+        }
+        else
+        {
+            SurrealDbInstrumentationEventSource.Log.LogInvalidConfigurationValue(
+                ContextPropagationLevelEnvVar,
+                configuration[ContextPropagationLevelEnvVar]!
+            );
+        }
+
+        if (
+            bool.TryParse(
+                configuration[SetDbQueryParametersEnvVar],
+                out bool setDbQueryParametersValue
+            )
+        )
+        {
+            this.SetDbQueryParameters = setDbQueryParametersValue;
+        }
+        else
+        {
+            SurrealDbInstrumentationEventSource.Log.LogInvalidConfigurationValue(
+                SetDbQueryParametersEnvVar,
+                configuration[SetDbQueryParametersEnvVar]!
+            );
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a filter function that determines whether or not to collect telemetry about a method.
+    /// </summary>
+    /// <remarks>
+    /// Notes:
+    /// <list type="bullet">
+    /// <item>The first parameter passed to the filter function is the event triggered before the method is being executed.</item>
+    /// <item>The return value for the filter function is interpreted as:
+    /// <list type="bullet">
+    /// <item>If filter returns <see langword="true" />, the method is collected.</item>
+    /// <item>If filter returns <see langword="false" /> or throws an exception the method is NOT collected.</item>
+    /// </list></item>
+    /// </list>
+    /// </remarks>
+    public Func<SurrealDbBeforeExecuteMethod, bool>? Filter { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the exception will be
+    /// recorded as <see cref="ActivityEvent"/> or not.
+    /// Default value: <see langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>For specification details see: <see
+    /// href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/exceptions/exceptions-spans.md"/>.</para>
+    /// </remarks>
+    public bool RecordException { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether or not the <see cref="SurrealDbClientInstrumentation"/>
+    /// should add the names and values of query parameters as the <c>db.query.parameter.{key}</c> tag.
+    /// Default value: <see langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>WARNING: SetDbQueryParameters will capture the raw
+    /// <c>Value</c>. Make sure your query parameters never
+    /// contain any sensitive data.</b>
+    /// </para>
+    /// </remarks>
+    internal bool SetDbQueryParameters { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to send traceparent information to a SurrealDB database.
+    /// </summary>
+    internal bool EnableTraceContextPropagation { get; set; }
+}

--- a/SurrealDb.Instrumentation/TracerProviderBuilderExtensions.cs
+++ b/SurrealDb.Instrumentation/TracerProviderBuilderExtensions.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using SurrealDb.Instrumentation;
+using SurrealDb.Instrumentation.Internals;
+
+namespace OpenTelemetry.Trace;
+
+/// <summary>
+/// Extension methods to simplify registering of dependency instrumentation.
+/// </summary>
+public static class TracerProviderBuilderExtensions
+{
+    /// <summary>
+    /// Enables SurrealDbClient instrumentation.
+    /// </summary>
+    /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
+    /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
+    public static TracerProviderBuilder AddSurrealDbClientInstrumentation(
+        this TracerProviderBuilder builder
+    ) =>
+        AddSurrealDbClientInstrumentation(
+            builder,
+            name: null,
+            configureSurrealDbClientTraceInstrumentationOptions: null
+        );
+
+    /// <summary>
+    /// Enables SurrealDbClient instrumentation.
+    /// </summary>
+    /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
+    /// <param name="configureSurrealDbClientTraceInstrumentationOptions">Callback action for configuring <see cref="SurrealDbClientTraceInstrumentationOptions"/>.</param>
+    /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
+    public static TracerProviderBuilder AddSurrealDbClientInstrumentation(
+        this TracerProviderBuilder builder,
+        Action<SurrealDbClientTraceInstrumentationOptions> configureSurrealDbClientTraceInstrumentationOptions
+    ) =>
+        AddSurrealDbClientInstrumentation(
+            builder,
+            name: null,
+            configureSurrealDbClientTraceInstrumentationOptions
+        );
+
+    /// <summary>
+    /// Enables SurrealDbClient instrumentation.
+    /// </summary>
+    /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
+    /// <param name="name">Name which is used when retrieving options.</param>
+    /// <param name="configureSurrealDbClientTraceInstrumentationOptions">Callback action for configuring <see cref="SurrealDbClientTraceInstrumentationOptions"/>.</param>
+    /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
+    public static TracerProviderBuilder AddSurrealDbClientInstrumentation(
+        this TracerProviderBuilder builder,
+        string? name,
+        Action<SurrealDbClientTraceInstrumentationOptions>? configureSurrealDbClientTraceInstrumentationOptions
+    )
+    {
+        name ??= Options.DefaultName;
+
+        if (configureSurrealDbClientTraceInstrumentationOptions != null)
+        {
+            builder.ConfigureServices(services =>
+                services.Configure(name, configureSurrealDbClientTraceInstrumentationOptions)
+            );
+        }
+
+        builder.AddInstrumentation(sp =>
+        {
+            var surrealDbOptions = sp.GetRequiredService<
+                IOptionsMonitor<SurrealDbClientTraceInstrumentationOptions>
+            >()
+                .Get(name);
+            SurrealDbClientInstrumentation.TracingOptions = surrealDbOptions;
+            return SurrealDbClientInstrumentation.Instance.HandleManager.AddTracingHandle();
+        });
+
+        string[] sources =
+        [
+            SurrealDbTelemetryHelper.ActivitySourceName,
+            SurrealDbTelemetryHelper.SurrealDbSystemName,
+        ];
+        builder.AddSource(sources);
+
+        return builder;
+    }
+}

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Http.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Http.cs
@@ -21,6 +21,9 @@ using SurrealDb.Net.Models;
 using SurrealDb.Net.Models.Auth;
 using SurrealDb.Net.Models.LiveQuery;
 using SurrealDb.Net.Models.Response;
+using SurrealDb.Net.Telemetry;
+using SurrealDb.Net.Telemetry.Events;
+using SurrealDb.Net.Telemetry.Events.Data;
 #if NET10_0_OR_GREATER
 using Microsoft.AspNetCore.JsonPatch.SystemTextJson;
 #else
@@ -1176,6 +1179,18 @@ internal class SurrealDbHttpEngine : ISurrealDbEngine
     )
     {
         long executionStartTime = Stopwatch.GetTimestamp();
+
+        var transientTraceData = new TransientTraceData();
+        await SurrealDbTelemetryChannel
+            .WriteAsync(
+                new SurrealDbExecuteMethod
+                {
+                    Data = transientTraceData,
+                    Namespace = _config.Ns,
+                    Database = _config.Db,
+                }
+            )
+            .ConfigureAwait(false);
 
         if (_version == null && request.Method != "version")
         {

--- a/SurrealDb.Net/Internals/Ws/SurrealDbWsRequest.cs
+++ b/SurrealDb.Net/Internals/Ws/SurrealDbWsRequest.cs
@@ -13,4 +13,8 @@ internal sealed class SurrealDbWsRequest
     [CborProperty("params")]
     [CborIgnoreIfDefault]
     public object?[]? Parameters { get; set; }
+
+    [CborProperty("traceparent")]
+    [CborIgnoreIfDefault]
+    public string? TraceParent { get; set; }
 }

--- a/SurrealDb.Net/SurrealDbClient.Methods.cs
+++ b/SurrealDb.Net/SurrealDbClient.Methods.cs
@@ -23,18 +23,18 @@ public abstract partial class BaseSurrealDbClient
 {
     public Task Authenticate(Jwt jwt, CancellationToken cancellationToken = default)
     {
-        return Engine.Authenticate(jwt, cancellationToken);
+        return RunWithTelemetryAsync(Engine.Authenticate(jwt, cancellationToken), "authenticate");
     }
 
     public Task Connect(CancellationToken cancellationToken = default)
     {
-        return Engine.Connect(cancellationToken);
+        return RunWithTelemetryAsync(Engine.Connect(cancellationToken), "connect");
     }
 
     public Task<T> Create<T>(T data, CancellationToken cancellationToken = default)
         where T : IRecord
     {
-        return Engine.Create(data, cancellationToken);
+        return RunWithTelemetryAsync(Engine.Create(data, cancellationToken), "create");
     }
 
     public Task<T> Create<T>(
@@ -43,7 +43,11 @@ public abstract partial class BaseSurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return Engine.Create(table, data, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Create(table, data, cancellationToken),
+            "create",
+            table
+        );
     }
 
     public Task<TOutput> Create<TData, TOutput>(
@@ -53,22 +57,29 @@ public abstract partial class BaseSurrealDbClient
     )
         where TOutput : IRecord
     {
-        return Engine.Create<TData, TOutput>(recordId, data, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Create<TData, TOutput>(recordId, data, cancellationToken),
+            "create"
+        );
     }
 
     public Task Delete(string table, CancellationToken cancellationToken = default)
     {
-        return Engine.Delete(table, cancellationToken);
+        return RunWithTelemetryAsync(Engine.Delete(table, cancellationToken), "delete", table);
     }
 
     public Task<bool> Delete(RecordId recordId, CancellationToken cancellationToken = default)
     {
-        return Engine.Delete(recordId, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Delete(recordId, cancellationToken),
+            "delete",
+            recordId.Table
+        );
     }
 
     public Task<bool> Delete(StringRecordId recordId, CancellationToken cancellationToken = default)
     {
-        return Engine.Delete(recordId, cancellationToken);
+        return RunWithTelemetryAsync(Engine.Delete(recordId, cancellationToken), "delete");
     }
 
     public void Dispose()
@@ -88,9 +99,17 @@ public abstract partial class BaseSurrealDbClient
         await Engine.DisposeAsync();
     }
 
-    public async Task<string> Export(
-        ExportOptions? options = default,
+    public Task<string> Export(
+        ExportOptions? options = null,
         CancellationToken cancellationToken = default
+    )
+    {
+        return RunWithTelemetryAsync(InternalExport(options, cancellationToken), "export");
+    }
+
+    private async Task<string> InternalExport(
+        ExportOptions? options,
+        CancellationToken cancellationToken
     )
     {
         if (Engine is ISurrealDbProviderEngine providerEngine)
@@ -135,10 +154,15 @@ public abstract partial class BaseSurrealDbClient
 
     public Task<bool> Health(CancellationToken cancellationToken = default)
     {
-        return Engine.Health(cancellationToken);
+        return RunWithTelemetryAsync(Engine.Health(cancellationToken), "health");
     }
 
-    public async Task Import(string input, CancellationToken cancellationToken = default)
+    public Task Import(string input, CancellationToken cancellationToken = default)
+    {
+        return RunWithTelemetryAsync(InternalImport(input, cancellationToken), "import");
+    }
+
+    private async Task InternalImport(string input, CancellationToken cancellationToken)
     {
         if (Engine is ISurrealDbProviderEngine providerEngine)
         {
@@ -169,7 +193,7 @@ public abstract partial class BaseSurrealDbClient
 
     public Task<T> Info<T>(CancellationToken cancellationToken = default)
     {
-        return Engine.Info<T>(cancellationToken);
+        return RunWithTelemetryAsync(Engine.Info<T>(cancellationToken), "info");
     }
 
     public Task<IEnumerable<T>> Insert<T>(
@@ -179,13 +203,20 @@ public abstract partial class BaseSurrealDbClient
     )
         where T : IRecord
     {
-        return Engine.Insert(table, data, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Insert(table, data, cancellationToken),
+            "insert",
+            table
+        );
     }
 
     public Task<T> InsertRelation<T>(T data, CancellationToken cancellationToken = default)
         where T : IRelationRecord
     {
-        return Engine.InsertRelation(data, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.InsertRelation(data, cancellationToken),
+            "insertrelation"
+        );
     }
 
     public Task<T> InsertRelation<T>(
@@ -195,20 +226,23 @@ public abstract partial class BaseSurrealDbClient
     )
         where T : IRelationRecord
     {
-        return Engine.InsertRelation(table, data, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.InsertRelation(table, data, cancellationToken),
+            "insertrelation",
+            table
+        );
     }
 
     public Task Invalidate(CancellationToken cancellationToken = default)
     {
-        return Engine.Invalidate(cancellationToken);
+        return RunWithTelemetryAsync(Engine.Invalidate(cancellationToken), "invalidate");
     }
 
     public Task Kill(Guid queryUuid, CancellationToken cancellationToken = default)
     {
-        return Engine.Kill(
-            queryUuid,
-            SurrealDbLiveQueryClosureReason.QueryKilled,
-            cancellationToken
+        return RunWithTelemetryAsync(
+            Engine.Kill(queryUuid, SurrealDbLiveQueryClosureReason.QueryKilled, cancellationToken),
+            "kill"
         );
     }
 
@@ -264,7 +298,10 @@ public abstract partial class BaseSurrealDbClient
     )
         where TMerge : IRecord
     {
-        return Engine.Merge<TMerge, TOutput>(data, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Merge<TMerge, TOutput>(data, cancellationToken),
+            "merge"
+        );
     }
 
     public Task<T> Merge<T>(
@@ -273,7 +310,11 @@ public abstract partial class BaseSurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return Engine.Merge<T>(recordId, data, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Merge<T>(recordId, data, cancellationToken),
+            "merge",
+            recordId.Table
+        );
     }
 
     public Task<T> Merge<T>(
@@ -282,7 +323,7 @@ public abstract partial class BaseSurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return Engine.Merge<T>(recordId, data, cancellationToken);
+        return RunWithTelemetryAsync(Engine.Merge<T>(recordId, data, cancellationToken), "merge");
     }
 
     public Task<IEnumerable<TOutput>> Merge<TMerge, TOutput>(
@@ -292,7 +333,11 @@ public abstract partial class BaseSurrealDbClient
     )
         where TMerge : class
     {
-        return Engine.Merge<TMerge, TOutput>(table, data, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Merge<TMerge, TOutput>(table, data, cancellationToken),
+            "merge",
+            table
+        );
     }
 
     public Task<IEnumerable<T>> Merge<T>(
@@ -301,7 +346,11 @@ public abstract partial class BaseSurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return Engine.Merge<T>(table, data, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Merge<T>(table, data, cancellationToken),
+            "merge",
+            table
+        );
     }
 
     public Task<T> Patch<T>(
@@ -311,7 +360,11 @@ public abstract partial class BaseSurrealDbClient
     )
         where T : class
     {
-        return Engine.Patch(recordId, patches, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Patch(recordId, patches, cancellationToken),
+            "patch",
+            recordId.Table
+        );
     }
 
     public Task<T> Patch<T>(
@@ -321,7 +374,7 @@ public abstract partial class BaseSurrealDbClient
     )
         where T : class
     {
-        return Engine.Patch(recordId, patches, cancellationToken);
+        return RunWithTelemetryAsync(Engine.Patch(recordId, patches, cancellationToken), "patch");
     }
 
     public Task<IEnumerable<T>> Patch<T>(
@@ -331,7 +384,11 @@ public abstract partial class BaseSurrealDbClient
     )
         where T : class
     {
-        return Engine.Patch(table, patches, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Patch(table, patches, cancellationToken),
+            "patch",
+            table
+        );
     }
 
 #if NET6_0_OR_GREATER
@@ -340,7 +397,11 @@ public abstract partial class BaseSurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return Engine.RawQuery(query.FormattedText, query.Parameters, cancellationToken);
+        return RunQueryWithTelemetryAsync(
+            Engine.RawQuery(query.FormattedText, query.Parameters, cancellationToken),
+            query.FormattedText,
+            query.Parameters
+        );
     }
 #else
     public Task<SurrealDbResponse> Query(
@@ -349,7 +410,11 @@ public abstract partial class BaseSurrealDbClient
     )
     {
         var (formattedQuery, parameters) = query.ExtractRawQueryParams();
-        return Engine.RawQuery(formattedQuery, parameters, cancellationToken);
+        return RunQueryWithTelemetryAsync(
+            Engine.RawQuery(formattedQuery, parameters, cancellationToken),
+            formattedQuery,
+            parameters
+        );
     }
 #endif
 
@@ -359,10 +424,11 @@ public abstract partial class BaseSurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return Engine.RawQuery(
+        var @params = parameters ?? ImmutableDictionary<string, object?>.Empty;
+        return RunQueryWithTelemetryAsync(
+            Engine.RawQuery(query, @params, cancellationToken),
             query,
-            parameters ?? ImmutableDictionary<string, object?>.Empty,
-            cancellationToken
+            @params
         );
     }
 
@@ -374,10 +440,15 @@ public abstract partial class BaseSurrealDbClient
     )
         where TOutput : class
     {
-        var outputs = await Engine
-            .Relate<TOutput, object>(table, new[] { @in }, new[] { @out }, null, cancellationToken)
-            .ConfigureAwait(false);
+        var task = Engine.Relate<TOutput, object>(
+            table,
+            new[] { @in },
+            new[] { @out },
+            null,
+            cancellationToken
+        );
 
+        var outputs = await RunWithTelemetryAsync(task, "relate", table).ConfigureAwait(false);
         return outputs.Single();
     }
 
@@ -390,10 +461,15 @@ public abstract partial class BaseSurrealDbClient
     )
         where TOutput : class
     {
-        var outputs = await Engine
-            .Relate<TOutput, TData>(table, new[] { @in }, new[] { @out }, data, cancellationToken)
-            .ConfigureAwait(false);
+        var task = Engine.Relate<TOutput, TData>(
+            table,
+            new[] { @in },
+            new[] { @out },
+            data,
+            cancellationToken
+        );
 
+        var outputs = await RunWithTelemetryAsync(task, "relate", table).ConfigureAwait(false);
         return outputs.Single();
     }
 
@@ -405,7 +481,11 @@ public abstract partial class BaseSurrealDbClient
     )
         where TOutput : class
     {
-        return Engine.Relate<TOutput, object>(table, ins, new[] { @out }, null, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Relate<TOutput, object>(table, ins, new[] { @out }, null, cancellationToken),
+            "relate",
+            table
+        );
     }
 
     public Task<IEnumerable<TOutput>> Relate<TOutput, TData>(
@@ -417,7 +497,11 @@ public abstract partial class BaseSurrealDbClient
     )
         where TOutput : class
     {
-        return Engine.Relate<TOutput, TData>(table, ins, new[] { @out }, data, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Relate<TOutput, TData>(table, ins, new[] { @out }, data, cancellationToken),
+            "relate",
+            table
+        );
     }
 
     public Task<IEnumerable<TOutput>> Relate<TOutput>(
@@ -428,7 +512,11 @@ public abstract partial class BaseSurrealDbClient
     )
         where TOutput : class
     {
-        return Engine.Relate<TOutput, object>(table, new[] { @in }, outs, null, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Relate<TOutput, object>(table, new[] { @in }, outs, null, cancellationToken),
+            "relate",
+            table
+        );
     }
 
     public Task<IEnumerable<TOutput>> Relate<TOutput, TData>(
@@ -440,7 +528,11 @@ public abstract partial class BaseSurrealDbClient
     )
         where TOutput : class
     {
-        return Engine.Relate<TOutput, TData>(table, new[] { @in }, outs, data, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Relate<TOutput, TData>(table, new[] { @in }, outs, data, cancellationToken),
+            "relate",
+            table
+        );
     }
 
     public Task<IEnumerable<TOutput>> Relate<TOutput>(
@@ -451,7 +543,11 @@ public abstract partial class BaseSurrealDbClient
     )
         where TOutput : class
     {
-        return Engine.Relate<TOutput, object>(table, ins, outs, null, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Relate<TOutput, object>(table, ins, outs, null, cancellationToken),
+            "relate",
+            table
+        );
     }
 
     public Task<IEnumerable<TOutput>> Relate<TOutput, TData>(
@@ -463,7 +559,11 @@ public abstract partial class BaseSurrealDbClient
     )
         where TOutput : class
     {
-        return Engine.Relate<TOutput, TData>(table, ins, outs, data, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Relate<TOutput, TData>(table, ins, outs, data, cancellationToken),
+            "relate",
+            table
+        );
     }
 
     public Task<TOutput> Relate<TOutput>(
@@ -474,7 +574,11 @@ public abstract partial class BaseSurrealDbClient
     )
         where TOutput : class
     {
-        return Engine.Relate<TOutput, object>(recordId, @in, @out, null, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Relate<TOutput, object>(recordId, @in, @out, null, cancellationToken),
+            "relate",
+            recordId.Table
+        );
     }
 
     public Task<TOutput> Relate<TOutput, TData>(
@@ -486,7 +590,11 @@ public abstract partial class BaseSurrealDbClient
     )
         where TOutput : class
     {
-        return Engine.Relate<TOutput, TData>(recordId, @in, @out, data, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Relate<TOutput, TData>(recordId, @in, @out, data, cancellationToken),
+            "relate",
+            recordId.Table
+        );
     }
 
     public Task<T> Run<T>(
@@ -495,7 +603,11 @@ public abstract partial class BaseSurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return Engine.Run<T>(name, null, args, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Run<T>(name, null, args, cancellationToken),
+            "run",
+            name
+        );
     }
 
     public Task<T> Run<T>(
@@ -505,7 +617,11 @@ public abstract partial class BaseSurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return Engine.Run<T>(name, version, args, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Run<T>(name, version, args, cancellationToken),
+            "run",
+            name
+        );
     }
 
     public Task<IEnumerable<T>> Select<T>(
@@ -513,12 +629,16 @@ public abstract partial class BaseSurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return Engine.Select<T>(table, cancellationToken);
+        return RunWithTelemetryAsync(Engine.Select<T>(table, cancellationToken), "select", table);
     }
 
     public Task<T?> Select<T>(RecordId recordId, CancellationToken cancellationToken = default)
     {
-        return Engine.Select<T?>(recordId, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Select<T?>(recordId, cancellationToken),
+            "select",
+            recordId.Table
+        );
     }
 
     public Task<T?> Select<T>(
@@ -526,7 +646,7 @@ public abstract partial class BaseSurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return Engine.Select<T?>(recordId, cancellationToken);
+        return RunWithTelemetryAsync(Engine.Select<T?>(recordId, cancellationToken), "select");
     }
 
     public Task<IEnumerable<TOutput>> Select<TStart, TEnd, TOutput>(
@@ -534,50 +654,53 @@ public abstract partial class BaseSurrealDbClient
         CancellationToken cancellationToken = default
     )
     {
-        return Engine.Select<TStart, TEnd, TOutput>(recordIdRange, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Select<TStart, TEnd, TOutput>(recordIdRange, cancellationToken),
+            "select"
+        );
     }
 
     public Task Set(string key, object value, CancellationToken cancellationToken = default)
     {
-        return Engine.Set(key, value, cancellationToken);
+        return RunWithTelemetryAsync(Engine.Set(key, value, cancellationToken), "set");
     }
 
     public Task SignIn(RootAuth root, CancellationToken cancellationToken = default)
     {
-        return Engine.SignIn(root, cancellationToken);
+        return RunWithTelemetryAsync(Engine.SignIn(root, cancellationToken), "signin");
     }
 
     public Task<Jwt> SignIn(NamespaceAuth nsAuth, CancellationToken cancellationToken = default)
     {
-        return Engine.SignIn(nsAuth, cancellationToken);
+        return RunWithTelemetryAsync(Engine.SignIn(nsAuth, cancellationToken), "signin");
     }
 
     public Task<Jwt> SignIn(DatabaseAuth dbAuth, CancellationToken cancellationToken = default)
     {
-        return Engine.SignIn(dbAuth, cancellationToken);
+        return RunWithTelemetryAsync(Engine.SignIn(dbAuth, cancellationToken), "signin");
     }
 
     public Task<Jwt> SignIn<T>(T scopeAuth, CancellationToken cancellationToken = default)
         where T : ScopeAuth
     {
-        return Engine.SignIn(scopeAuth, cancellationToken);
+        return RunWithTelemetryAsync(Engine.SignIn(scopeAuth, cancellationToken), "signin");
     }
 
     public Task<Jwt> SignUp<T>(T scopeAuth, CancellationToken cancellationToken = default)
         where T : ScopeAuth
     {
-        return Engine.SignUp(scopeAuth, cancellationToken);
+        return RunWithTelemetryAsync(Engine.SignUp(scopeAuth, cancellationToken), "signup");
     }
 
     public Task Unset(string key, CancellationToken cancellationToken = default)
     {
-        return Engine.Unset(key, cancellationToken);
+        return RunWithTelemetryAsync(Engine.Unset(key, cancellationToken), "unset");
     }
 
     public Task<T> Update<T>(T data, CancellationToken cancellationToken = default)
         where T : IRecord
     {
-        return Engine.Update(data, cancellationToken);
+        return RunWithTelemetryAsync(Engine.Update(data, cancellationToken), "update");
     }
 
     public Task<TOutput> Update<TData, TOutput>(
@@ -587,7 +710,10 @@ public abstract partial class BaseSurrealDbClient
     )
         where TOutput : IRecord
     {
-        return Engine.Update<TData, TOutput>(recordId, data, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Update<TData, TOutput>(recordId, data, cancellationToken),
+            "update"
+        );
     }
 
     public Task<IEnumerable<T>> Update<T>(
@@ -597,7 +723,11 @@ public abstract partial class BaseSurrealDbClient
     )
         where T : class
     {
-        return Engine.Update(table, data, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Update(table, data, cancellationToken),
+            "update",
+            table
+        );
     }
 
     public Task<IEnumerable<TOutput>> Update<TData, TOutput>(
@@ -607,7 +737,11 @@ public abstract partial class BaseSurrealDbClient
     )
         where TOutput : IRecord
     {
-        return Engine.Update<TData, TOutput>(table, data, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Update<TData, TOutput>(table, data, cancellationToken),
+            "update",
+            table
+        );
     }
 
     public Task<TOutput> Update<TData, TOutput>(
@@ -617,13 +751,17 @@ public abstract partial class BaseSurrealDbClient
     )
         where TOutput : IRecord
     {
-        return Engine.Update<TData, TOutput>(recordId, data, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Update<TData, TOutput>(recordId, data, cancellationToken),
+            "update",
+            recordId.Table
+        );
     }
 
     public Task<T> Upsert<T>(T data, CancellationToken cancellationToken = default)
         where T : IRecord
     {
-        return Engine.Upsert(data, cancellationToken);
+        return RunWithTelemetryAsync(Engine.Upsert(data, cancellationToken), "upsert");
     }
 
     public Task<TOutput> Upsert<TData, TOutput>(
@@ -633,7 +771,10 @@ public abstract partial class BaseSurrealDbClient
     )
         where TOutput : IRecord
     {
-        return Engine.Upsert<TData, TOutput>(recordId, data, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Upsert<TData, TOutput>(recordId, data, cancellationToken),
+            "upsert"
+        );
     }
 
     public Task<IEnumerable<T>> Upsert<T>(
@@ -643,7 +784,11 @@ public abstract partial class BaseSurrealDbClient
     )
         where T : class
     {
-        return Engine.Upsert(table, data, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Upsert(table, data, cancellationToken),
+            "upsert",
+            table
+        );
     }
 
     public Task<IEnumerable<TOutput>> Upsert<TData, TOutput>(
@@ -653,7 +798,11 @@ public abstract partial class BaseSurrealDbClient
     )
         where TOutput : IRecord
     {
-        return Engine.Upsert<TData, TOutput>(table, data, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Upsert<TData, TOutput>(table, data, cancellationToken),
+            "upsert",
+            table
+        );
     }
 
     public Task<TOutput> Upsert<TData, TOutput>(
@@ -663,16 +812,20 @@ public abstract partial class BaseSurrealDbClient
     )
         where TOutput : IRecord
     {
-        return Engine.Upsert<TData, TOutput>(recordId, data, cancellationToken);
+        return RunWithTelemetryAsync(
+            Engine.Upsert<TData, TOutput>(recordId, data, cancellationToken),
+            "upsert",
+            recordId.Table
+        );
     }
 
     public Task Use(string ns, string db, CancellationToken cancellationToken = default)
     {
-        return Engine.Use(ns, db, cancellationToken);
+        return RunWithTelemetryAsync(Engine.Use(ns, db, cancellationToken), "use");
     }
 
     public Task<string> Version(CancellationToken cancellationToken = default)
     {
-        return Engine.Version(cancellationToken);
+        return RunWithTelemetryAsync(Engine.Version(cancellationToken), "version");
     }
 }

--- a/SurrealDb.Net/SurrealDbClient.Telemetry.cs
+++ b/SurrealDb.Net/SurrealDbClient.Telemetry.cs
@@ -1,0 +1,115 @@
+﻿using SurrealDb.Net.Models.Response;
+using SurrealDb.Net.Telemetry;
+using SurrealDb.Net.Telemetry.Events;
+
+namespace SurrealDb.Net;
+
+public abstract partial class BaseSurrealDbClient
+{
+    private async Task RunWithTelemetryAsync(
+        Task method,
+        string methodName,
+        string? tableOrFunction = null
+    )
+    {
+        await StartTelemetryAsync(methodName, tableOrFunction).ConfigureAwait(false);
+
+        try
+        {
+            await method.ConfigureAwait(false);
+
+            await SurrealDbTelemetryChannel
+                .WriteAsync(new SurrealDbAfterExecuteMethod())
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            await SurrealDbTelemetryChannel
+                .WriteAsync(new SurrealDbExecuteError { Exception = ex })
+                .ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private async Task<T> RunWithTelemetryAsync<T>(
+        Task<T> method,
+        string methodName,
+        string? tableOrFunction = null
+    )
+    {
+        await StartTelemetryAsync(methodName, tableOrFunction).ConfigureAwait(false);
+
+        try
+        {
+            var response = await method.ConfigureAwait(false);
+
+            await SurrealDbTelemetryChannel
+                .WriteAsync(new SurrealDbAfterExecuteMethod())
+                .ConfigureAwait(false);
+
+            return response;
+        }
+        catch (Exception ex)
+        {
+            await SurrealDbTelemetryChannel
+                .WriteAsync(new SurrealDbExecuteError { Exception = ex })
+                .ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private async Task<SurrealDbResponse> RunQueryWithTelemetryAsync(
+        Task<SurrealDbResponse> method,
+        string query,
+        IReadOnlyDictionary<string, object?> parameters
+    )
+    {
+        const string methodName = "query";
+
+        await StartTelemetryAsync(methodName, null).ConfigureAwait(false);
+
+        await SurrealDbTelemetryChannel
+            .WriteAsync(new SurrealDbBeforeExecuteQuery { Query = query, Parameters = parameters })
+            .ConfigureAwait(false);
+
+        try
+        {
+            var response = await method.ConfigureAwait(false);
+
+            await SurrealDbTelemetryChannel
+                .WriteAsync(new SurrealDbAfterExecuteMethod { BatchSize = response.Count })
+                .ConfigureAwait(false);
+
+            return response;
+        }
+        catch (Exception ex)
+        {
+            await SurrealDbTelemetryChannel
+                .WriteAsync(new SurrealDbExecuteError { Exception = ex })
+                .ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private async Task StartTelemetryAsync(string methodName, string? tableOrFunction)
+    {
+        await SurrealDbTelemetryChannel
+            .WriteAsync(
+                new SurrealDbBeforeExecuteMethod
+                {
+                    Address = Uri,
+                    Method = methodName,
+                    Summary = CreateSummary(methodName, tableOrFunction),
+                    Table = tableOrFunction,
+                }
+            )
+            .ConfigureAwait(false);
+    }
+
+    private static string CreateSummary(string methodName, string? tableOrFunction)
+    {
+        return string.IsNullOrEmpty(tableOrFunction)
+            ? $"{methodName};"
+            : $"{methodName} {tableOrFunction};";
+    }
+}

--- a/SurrealDb.Net/Telemetry/Events/Data/TransientTraceData.cs
+++ b/SurrealDb.Net/Telemetry/Events/Data/TransientTraceData.cs
@@ -1,0 +1,9 @@
+﻿namespace SurrealDb.Net.Telemetry.Events.Data;
+
+/// <summary>
+/// Data holder for the current trace.
+/// </summary>
+public sealed class TransientTraceData
+{
+    public string? Traceparent { get; set; }
+}

--- a/SurrealDb.Net/Telemetry/Events/ISurrealDbTelemetryEvent.cs
+++ b/SurrealDb.Net/Telemetry/Events/ISurrealDbTelemetryEvent.cs
@@ -1,0 +1,3 @@
+﻿namespace SurrealDb.Net.Telemetry.Events;
+
+public interface ISurrealDbTelemetryEvent;

--- a/SurrealDb.Net/Telemetry/Events/SurrealDbAfterExecuteMethod.cs
+++ b/SurrealDb.Net/Telemetry/Events/SurrealDbAfterExecuteMethod.cs
@@ -1,0 +1,11 @@
+﻿namespace SurrealDb.Net.Telemetry.Events;
+
+/// <summary>
+/// Event triggered after any SurrealDB method is executed from the client.
+/// </summary>
+public sealed class SurrealDbAfterExecuteMethod : ISurrealDbTelemetryEvent
+{
+    public const string Name = "SurrealDb.Method.AfterExecute";
+
+    public int? BatchSize { get; set; }
+}

--- a/SurrealDb.Net/Telemetry/Events/SurrealDbBeforeExecuteMethod.cs
+++ b/SurrealDb.Net/Telemetry/Events/SurrealDbBeforeExecuteMethod.cs
@@ -1,0 +1,14 @@
+﻿namespace SurrealDb.Net.Telemetry.Events;
+
+/// <summary>
+/// Event triggered before any SurrealDB method is executed from the client.
+/// </summary>
+public sealed class SurrealDbBeforeExecuteMethod : ISurrealDbTelemetryEvent
+{
+    public const string Name = "SurrealDb.Method.BeforeExecute";
+
+    public string Summary { get; set; } = string.Empty;
+    public string Method { get; set; } = string.Empty;
+    public Uri? Address { get; set; }
+    public string? Table { get; set; }
+}

--- a/SurrealDb.Net/Telemetry/Events/SurrealDbBeforeExecuteQuery.cs
+++ b/SurrealDb.Net/Telemetry/Events/SurrealDbBeforeExecuteQuery.cs
@@ -1,0 +1,12 @@
+﻿namespace SurrealDb.Net.Telemetry.Events;
+
+/// <summary>
+/// Additional information from an event triggered before a "query" method is executed.
+/// </summary>
+public sealed class SurrealDbBeforeExecuteQuery : ISurrealDbTelemetryEvent
+{
+    public const string Name = "SurrealDb.Query.BeforeExecute";
+
+    public string? Query { get; set; }
+    public IReadOnlyDictionary<string, object?>? Parameters { get; set; }
+}

--- a/SurrealDb.Net/Telemetry/Events/SurrealDbExecuteError.cs
+++ b/SurrealDb.Net/Telemetry/Events/SurrealDbExecuteError.cs
@@ -1,0 +1,11 @@
+﻿namespace SurrealDb.Net.Telemetry.Events;
+
+/// <summary>
+/// Event triggered when a SurrealDB method failed.
+/// </summary>
+public sealed class SurrealDbExecuteError : ISurrealDbTelemetryEvent
+{
+    public const string Name = "SurrealDb.Error.Execute";
+
+    public Exception? Exception { get; set; }
+}

--- a/SurrealDb.Net/Telemetry/Events/SurrealDbExecuteMethod.cs
+++ b/SurrealDb.Net/Telemetry/Events/SurrealDbExecuteMethod.cs
@@ -1,0 +1,15 @@
+﻿using SurrealDb.Net.Telemetry.Events.Data;
+
+namespace SurrealDb.Net.Telemetry.Events;
+
+/// <summary>
+/// Event triggered when a SurrealDB method is executed from the client.
+/// </summary>
+public sealed class SurrealDbExecuteMethod : ISurrealDbTelemetryEvent
+{
+    public const string Name = "SurrealDb.Method.Execute";
+
+    public string? Namespace { get; set; }
+    public string? Database { get; set; }
+    public TransientTraceData? Data { get; set; }
+}

--- a/SurrealDb.Net/Telemetry/SurrealDbTelemetryChannel.cs
+++ b/SurrealDb.Net/Telemetry/SurrealDbTelemetryChannel.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading.Channels;
+using SurrealDb.Net.Telemetry.Events;
+
+namespace SurrealDb.Net.Telemetry;
+
+public static class SurrealDbTelemetryChannel
+{
+    private static readonly Channel<ISurrealDbTelemetryEvent> _channel =
+        Channel.CreateBounded<ISurrealDbTelemetryEvent>(
+            new BoundedChannelOptions(1_000)
+            {
+                SingleReader = true,
+                SingleWriter = true,
+                FullMode = BoundedChannelFullMode.DropOldest,
+            }
+        );
+
+    internal static async Task WriteAsync(ISurrealDbTelemetryEvent item)
+    {
+        await _channel.Writer.WriteAsync(item).ConfigureAwait(false);
+    }
+
+    public static IAsyncEnumerable<ISurrealDbTelemetryEvent> ReadAllAsync(
+        CancellationToken cancellationToken = default
+    )
+    {
+        return _channel.Reader.ReadAllAsync(cancellationToken);
+    }
+}

--- a/SurrealDb.sln
+++ b/SurrealDb.sln
@@ -67,6 +67,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SurrealDb.Embedded.SurrealK
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SurrealDb.Embedded.Internals", "SurrealDb.Embedded.Internals\SurrealDb.Embedded.Internals.csproj", "{8ED80F32-D22A-4267-9BDE-865223C99020}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Telemetry", "Telemetry", "{B6EB7AB2-9040-4B59-8AFE-E699D5990494}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SurrealDb.Instrumentation", "SurrealDb.Instrumentation\SurrealDb.Instrumentation.csproj", "{3676BA71-1606-42A4-8039-4D86C1F8932C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -157,6 +161,10 @@ Global
 		{8ED80F32-D22A-4267-9BDE-865223C99020}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8ED80F32-D22A-4267-9BDE-865223C99020}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8ED80F32-D22A-4267-9BDE-865223C99020}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3676BA71-1606-42A4-8039-4D86C1F8932C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3676BA71-1606-42A4-8039-4D86C1F8932C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3676BA71-1606-42A4-8039-4D86C1F8932C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3676BA71-1606-42A4-8039-4D86C1F8932C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -183,6 +191,7 @@ Global
 		{94D34588-23C7-40CA-8ADB-6057603DA031} = {ED80259F-C52A-4936-9345-E8E3ABE19FBF}
 		{E7048C18-3B7E-4B00-8550-3FBDF10910E0} = {ED80259F-C52A-4936-9345-E8E3ABE19FBF}
 		{8ED80F32-D22A-4267-9BDE-865223C99020} = {ED80259F-C52A-4936-9345-E8E3ABE19FBF}
+		{3676BA71-1606-42A4-8039-4D86C1F8932C} = {B6EB7AB2-9040-4B59-8AFE-E699D5990494}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {70C100EF-E131-45C0-9515-02FC4823BA20}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What does this change do?

Configure OTEL for the SurrealDB C# client SDK.

* Create a new `Activity` (Span), set tags & set `traceparent` to follow the trace to the server
* Implemented early the Traces and Metrics extensions that should be placed in a proper `OpenTelemetry.Instrumentation.Contrib.SurrealDbClient` NuGet package in the future 

## What is your testing strategy?

Local testing with a local collector.

Tested & working with the changes from https://github.com/surrealdb/surrealdb/pull/6799

## Is this related to any issues?

Closes #12 
Iterated from the work of @thompson-tomo on #206, closes #206
Implemented from the conventions https://github.com/open-telemetry/semantic-conventions/pull/2571

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)