### PR TITLE
fix: consume null payload in NONE and RecordId converters

### DIFF
--- a/SurrealDb.Net.Tests/Serializers/Cbor/NoneConverterTests.cs
+++ b/SurrealDb.Net.Tests/Serializers/Cbor/NoneConverterTests.cs
@@ -19,4 +19,23 @@ public class NoneConverterTests : BaseCborConverterTests
 
         result.Should().Be(new None());
     }
+
+    /// <summary>
+    /// Regression test for: NoneConverter.Read did not consume the F6 (null) byte after
+    /// reading the C6 (tag 6) semantic tag, leaving the reader mispositioned.
+    /// If the bug is present, deserializing the element following None in a sequence throws
+    /// or returns a wrong value because the reader is still pointing at the unconsumed F6.
+    /// </summary>
+    [Test]
+    public async Task DeserializeInsideSequence()
+    {
+        // CBOR: array(2) [ tag(6) null, uint(42) ]
+        // 82       = array of length 2
+        // c6 f6    = tag(6) + null  →  None
+        // 18 2a    = uint(42)
+        var result = await DeserializeCborBinaryAsHexaAsync<(None, int)>("82c6f6182a");
+
+        result.Item1.Should().Be(new None());
+        result.Item2.Should().Be(42);
+    }
 }

--- a/SurrealDb.Net.Tests/Serializers/Cbor/RecordIdConverterTests.cs
+++ b/SurrealDb.Net.Tests/Serializers/Cbor/RecordIdConverterTests.cs
@@ -42,4 +42,72 @@ public class RecordIdConverterTests : BaseCborConverterTests
 
         result.Should().Be(expected);
     }
+
+    [Test]
+    public async Task DeserializeFromNull()
+    {
+        // CBOR: f6 = null
+        var result = await DeserializeCborBinaryAsHexaAsync<RecordId>("f6");
+
+        result.Should().BeNull();
+    }
+
+    /// <summary>
+    /// Regression test for: RecordIdConverter.Read used a switch expression where the Null
+    /// arm returned <c>default!</c> without consuming the F6 (null) byte, leaving the reader
+    /// mispositioned. If the bug is present, deserializing the element following a null RecordId
+    /// in a sequence throws or returns a wrong value.
+    /// </summary>
+    [Test]
+    public async Task DeserializeFromNullInsideSequence()
+    {
+        // CBOR: array(2) [ null, uint(42) ]
+        // 82       = array of length 2
+        // f6       = null  →  null RecordId
+        // 18 2a    = uint(42)
+        var result = await DeserializeCborBinaryAsHexaAsync<(RecordId?, int)>("82f6182a");
+
+        result.Item1.Should().BeNull();
+        result.Item2.Should().Be(42);
+    }
+
+    /// <summary>
+    /// Regression test for the exact production scenario: SurrealDB NONE (Tag(6)+null = C6 F6)
+    /// appears as the first element of a tuple array ID. GetCurrentDataItemType() consumes the
+    /// semantic tag and peeks at null, but without an explicit ReadNull() the F6 byte remains
+    /// unconsumed and is read by the next tuple element's converter, silently losing the value.
+    /// </summary>
+    [Test]
+    public async Task DeserializeFromTaggedNullInsideSequence()
+    {
+        // CBOR: array(2) [ tag(6) null, "hello" ]
+        // 82          = array of length 2
+        // c6 f6       = tag(6) + null  →  NONE, read as null RecordId
+        // 65 68656c6c6f = text(5) "hello"
+        var result = await DeserializeCborBinaryAsHexaAsync<(RecordId?, string)>(
+            "82c6f66568656c6c6f"
+        );
+
+        result.Item1.Should().BeNull();
+        result.Item2.Should().Be("hello");
+    }
+
+    /// <summary>
+    /// Confirms the non-null path works inside a tuple: a tagged RecordId array followed by
+    /// another element should deserialize both correctly.
+    /// </summary>
+    [Test]
+    public async Task DeserializeFromRecordIdInsideSequence()
+    {
+        // CBOR: array(2) [ tag(8) array(2) ["post", "first"], uint(42) ]
+        // 82                               = array of length 2
+        // c8 82 64 706f7374 65 6669727374  = tag(8) + array(2) [ "post", "first" ]
+        // 18 2a                            = uint(42)
+        var result = await DeserializeCborBinaryAsHexaAsync<(RecordId, int)>(
+            "82c88264706f7374656669727374182a"
+        );
+
+        result.Item1.Should().Be(new RecordIdOfString("post", "first"));
+        result.Item2.Should().Be(42);
+    }
 }

--- a/SurrealDb.Net/Internals/Cbor/Converters/NoneConverter.cs
+++ b/SurrealDb.Net/Internals/Cbor/Converters/NoneConverter.cs
@@ -17,6 +17,8 @@ internal class NoneConverter : CborConverterBase<None>
             throw new CborException("Expected a CBOR type of NONE");
         }
 
+        reader.ReadNull();
+
         return new();
     }
 

--- a/SurrealDb.Net/Internals/Cbor/Converters/RecordIdConverter.cs
+++ b/SurrealDb.Net/Internals/Cbor/Converters/RecordIdConverter.cs
@@ -18,13 +18,15 @@ internal sealed class RecordIdConverter : CborConverterBase<RecordId>
 
     public override RecordId Read(ref CborReader reader)
     {
-        if (reader.GetCurrentDataItemType() == CborDataItemType.Null)
+        var dataType = reader.GetCurrentDataItemType();
+
+        if (dataType == CborDataItemType.Null)
         {
             reader.ReadNull();
             return default!;
         }
 
-        return reader.GetCurrentDataItemType() switch
+        return dataType switch
         {
             CborDataItemType.Array => ReadRecordIdFromArray(ref reader),
             CborDataItemType.String => throw new CborException(

--- a/SurrealDb.Net/Internals/Cbor/Converters/RecordIdConverter.cs
+++ b/SurrealDb.Net/Internals/Cbor/Converters/RecordIdConverter.cs
@@ -18,9 +18,14 @@ internal sealed class RecordIdConverter : CborConverterBase<RecordId>
 
     public override RecordId Read(ref CborReader reader)
     {
+        if (reader.GetCurrentDataItemType() == CborDataItemType.Null)
+        {
+            reader.ReadNull();
+            return default!;
+        }
+
         return reader.GetCurrentDataItemType() switch
         {
-            CborDataItemType.Null => default!,
             CborDataItemType.Array => ReadRecordIdFromArray(ref reader),
             CborDataItemType.String => throw new CborException(
                 $"The type '{nameof(StringRecordId)}' was not expected here"


### PR DESCRIPTION
When a CBOR semantic tag precedes a null value (e.g. Tag(6)+null for SurrealDB NONE, or Tag(8)+null for a nullable RecordId), two converters read the tag but left the following null byte unconsumed in the reader.

NoneConverter.Read: called TryReadSemanticTag() to consume the tag, then returned without reading the null payload (0xF6).

RecordIdConverter.Read: called GetCurrentDataItemType(), which internally calls SkipSemanticTag() and peeks at the next byte, but the switch expression matched CborDataItemType.Null and returned default! without advancing the reader past the null byte.

In both cases the unconsumed null byte was then read by the next converter in sequence (e.g. a string converter inside a tuple), causing data loss for any tuple element that followed a NONE or null RecordId.

Fix: explicitly call reader.ReadNull() to consume the null payload before returning in both converters. This ensures the reader is correctly positioned for subsequent tuple elements.

Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Without it, deserializing results from certain queries doesn't work.

## What does this change do?

Fixes deserialization when a CBOR semantic tag precedes a null value (e.g. Tag(6)+null for
SurrealDB NONE, or Tag(8)+null for a nullable RecordId)

## What is your testing strategy?

The fix is actively being used in the development of a product. I'll add to your existing tests after reviewing them to understand your testing approach.

## Is this related to any issues?

 https://github.com/surrealdb/surrealdb.net/issues/234

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)