### PR TITLE
fix(cbor): support SurrealDB v3 UUID encoding (tag(37, tstr))

### DIFF
--- a/SurrealDb.Net/Internals/Cbor/Converters/GuidConverter.cs
+++ b/SurrealDb.Net/Internals/Cbor/Converters/GuidConverter.cs
@@ -11,6 +11,24 @@ internal sealed class GuidConverter : CborConverterBase<Guid>
     public override Guid Read(ref CborReader reader)
     {
 #if NET8_0_OR_GREATER
+        // Do NOT call TryReadSemanticTag before GetCurrentDataItemType.
+        // TryReadSemanticTag sets _state = CborReaderState.Data after consuming the tag.
+        // GetCurrentDataItemType then calls SkipSemanticTag → GetHeader, which — because
+        // state is Data — reads one extra byte from the stream, misaligning the cursor.
+        // This produces the "[1] Expected major type ByteString (2)" error at offset 1.
+        //
+        // Instead, let GetCurrentDataItemType handle tag-skipping on its own via its
+        // internal SkipSemanticTag call, which leaves the cursor on the value header
+        // in CborReaderState.Header (peeked but not consumed).
+        var dataItemType = reader.GetCurrentDataItemType();
+
+        // SurrealDB v2 and earlier: tag(37, bstr(16)) — 16-byte big-endian UUID.
+        // SurrealDB v3+:            tag(37, tstr)     — UUID as a text string.
+        if (dataItemType == CborDataItemType.String)
+        {
+            return Guid.Parse(reader.ReadString()!);
+        }
+
         var value = reader.ReadByteString();
 
         if (value.Length != CBOR_ARRAY_SIZE)


### PR DESCRIPTION
 ## What is the motivation?                               

  SurrealDB v3 changed the CBOR encoding of UUIDs from `tag(37, bstr(16))`                                                                                                                                                                                                                                             
  (16-byte big-endian byte string) to `tag(37, tstr)` (plain text string).
  The existing `GuidConverter.Read` called `ReadByteString()` unconditionally,                                                                                                                                                                                                                                         
  causing a `CborException: [1] Expected major type ByteString (2)` on any
  response that includes a UUID — live query IDs, record IDs, etc.

  ## What does this change do?

  Uses `GetCurrentDataItemType()` to detect which encoding SurrealDB sent,
  then branches accordingly:
  - `Guid.Parse(ReadString())` for SurrealDB v3+ (`tag(37, tstr)`)
  - `ReadByteString()` for SurrealDB v2 and earlier (`tag(37, bstr(16))`)

  Fully backwards-compatible with both versions.

  The comment also documents a subtle ordering constraint: `TryReadSemanticTag`
  must NOT be called before `GetCurrentDataItemType`, because it consumes the
  tag and leaves the CBOR cursor misaligned — which is what produces the
  `[1] Expected major type ByteString (2)` error.

  ## What is your testing strategy?

  Verified against a live SurrealDB v3.0.5 instance. LIVE queries, `RawQuery`,
  and `GetValue<Guid>()` all deserialize UUIDs correctly. The old byte-string
  path remains untouched for v2 compatibility.

  ## Is this related to any issues?

  N/A

  ## Have you read the Contributing Guidelines?

  - [x] I have read the Contributing Guidelines