### PR TITLE
Fix crash on empty type field in CBOR result

### DIFF
--- a/SurrealDb.Net.Tests/Serializers/Cbor/SurrealDbResultConverterTests.cs
+++ b/SurrealDb.Net.Tests/Serializers/Cbor/SurrealDbResultConverterTests.cs
@@ -36,4 +36,23 @@ public class SurrealDbResultConverterTests : BaseCborConverterTests
 
         okResult.GetValue<string>().Should().BeNull();
     }
+
+    // See https://github.com/surrealdb/surrealdb.net/issues/227
+    // and https://github.com/surrealdb/surrealdb.net/issues/236
+    [Test]
+    public async Task DeserializeResultWithEmptyTypeShouldNotThrow()
+    {
+        var result = await DeserializeCborBinaryAsHexaAsync<ISurrealDbResult>(
+            "a466726573756c74c6f666737461747573624f4b6474696d6566363630c2b573647479706560"
+        );
+
+        result.Should().BeOfType<SurrealDbOkResult>();
+
+        var okResult = (SurrealDbOkResult)result;
+        okResult.Status.Should().Be("OK");
+        okResult.IsOk.Should().BeTrue();
+        okResult.Type.Should().Be(SurrealDbResponseType.Other);
+
+        okResult.GetValue<string>().Should().BeNull();
+    }
 }

--- a/SurrealDb.Net/Internals/Cbor/Converters/SurrealDbResultConverter.cs
+++ b/SurrealDb.Net/Internals/Cbor/Converters/SurrealDbResultConverter.cs
@@ -103,7 +103,7 @@ internal sealed class SurrealDbResultConverter : CborConverterBase<ISurrealDbRes
             if (key.SequenceEqual("type"u8))
             {
                 var typeString = reader.ReadString();
-                if (typeString is null)
+                if (string.IsNullOrWhiteSpace(typeString))
                 {
                     continue;
                 }


### PR DESCRIPTION
## Root cause

`SurrealDbResultConverter.Read` (in `SurrealDb.Net/Internals/Cbor/Converters/SurrealDbResultConverter.cs`) only guarded the `type` field against a `null` string:

```csharp
var typeString = reader.ReadString();
if (typeString is null)
{
    continue;
}
```

SurrealDB 3.x can return an empty (or whitespace) string for this field — reported for trivial queries such as `RETURN 1;` and during schema initialization. An empty string bypasses the `null` guard and is passed to `SurrealDbResponseTypeExtensions.From("")`, which returns `null`, triggering:

```
Dahomey.Cbor.CborException : '' is not a valid result type.
```

Fixes #227
Fixes #236

## Fix

Widen the guard to `string.IsNullOrWhiteSpace(typeString)`, so empty/whitespace type values are skipped exactly the same way `null` values already were — leaving `type` at its default `SurrealDbResponseType.Other`. This is the exact fix suggested by a reporter in #227.

```csharp
var typeString = reader.ReadString();
if (string.IsNullOrWhiteSpace(typeString))
{
    continue;
}
```

## Test

Added `SurrealDbResultConverterTests.DeserializeResultWithEmptyTypeShouldNotThrow`, a unit test that deserializes a CBOR payload containing an empty `"type"` string and asserts it resolves to a `SurrealDbOkResult` with `Type == SurrealDbResponseType.Other` instead of throwing.

Confirmed the test reproduces the exact reported `CborException: '' is not a valid result type.` when the fix is reverted, and passes with the fix applied.

## Verification run

- `dotnet csharpier --check .` — clean, no reformatting needed
- `dotnet build SurrealDb.Net/SurrealDb.Net.csproj` — 0 warnings, 0 errors
- `dotnet build SurrealDb.Net.Tests/SurrealDb.Net.Tests.csproj` — 0 warnings, 0 errors
- `SurrealDb.Net.Tests --treenode-filter "/*/*/SurrealDbResultConverterTests/*"` — 3/3 passed
- `SurrealDb.Net.Tests --treenode-filter "/*/*/*ConverterTests/*"` — 98/98 passed (no regressions across all CBOR converter tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)