### PR TITLE
Move CborDebugHelper into Internals/Cbor

### DIFF
--- a/SurrealDb.Embedded.InMemory/SurrealDb.Embedded.InMemory.csproj
+++ b/SurrealDb.Embedded.InMemory/SurrealDb.Embedded.InMemory.csproj
@@ -30,7 +30,7 @@
     <Compile Include="..\SurrealDb.Net\Internals\Extensions\StringExtensions.cs" Link="Internals\Extensions\StringExtensions.cs" />
     <Compile Include="..\SurrealDb.Net\Internals\Extensions\SurrealDbLoggerExtensions.cs" Link="Internals\Extensions\SurrealDbLoggerExtensions.cs" />
     <Compile Include="..\SurrealDb.Net\Internals\Stream\MemoryStreamProvider.cs" Link="Internals\Stream\MemoryStreamProvider.cs" />
-    <Compile Include="..\SurrealDb.Net\Internals\Helpers\CborDebugHelper.cs" Link="Internals\Helpers\CborDebugHelper.cs" />
+    <Compile Include="..\SurrealDb.Net\Internals\Cbor\CborDebugHelper.cs" Link="Internals\Cbor\CborDebugHelper.cs" />
     <Compile Include="..\SurrealDb.Net\Internals\Sessions\SessionInfo.cs" Link="Internals\Sessions\SessionInfo.cs" />
   </ItemGroup>
 

--- a/SurrealDb.Embedded.Internals/SurrealDb.Embedded.Internals.csproj
+++ b/SurrealDb.Embedded.Internals/SurrealDb.Embedded.Internals.csproj
@@ -13,7 +13,7 @@
       <Compile Include="..\SurrealDb.Net\Internals\Extensions\StringExtensions.cs" Link="Internals\Extensions\StringExtensions.cs" />
       <Compile Include="..\SurrealDb.Net\Internals\Extensions\SurrealDbLoggerExtensions.cs" Link="Internals\Extensions\SurrealDbLoggerExtensions.cs" />
       <Compile Include="..\SurrealDb.Net\Internals\Stream\MemoryStreamProvider.cs" Link="Internals\Stream\MemoryStreamProvider.cs" />
-      <Compile Include="..\SurrealDb.Net\Internals\Helpers\CborDebugHelper.cs" Link="Internals\Helpers\CborDebugHelper.cs" />
+      <Compile Include="..\SurrealDb.Net\Internals\Cbor\CborDebugHelper.cs" Link="Internals\Cbor\CborDebugHelper.cs" />
       <Compile Include="..\SurrealDb.Net\Internals\Sessions\SessionInfo.cs" Link="Internals\Sessions\SessionInfo.cs" />
     </ItemGroup>
 

--- a/SurrealDb.Embedded.Internals/SurrealDbEmbeddedEngine.cs
+++ b/SurrealDb.Embedded.Internals/SurrealDbEmbeddedEngine.cs
@@ -15,7 +15,6 @@ using SurrealDb.Net.Internals;
 using SurrealDb.Net.Internals.Cbor;
 using SurrealDb.Net.Internals.DependencyInjection;
 using SurrealDb.Net.Internals.Extensions;
-using SurrealDb.Net.Internals.Helpers;
 using SurrealDb.Net.Internals.Models.LiveQuery;
 using SurrealDb.Net.Internals.Stream;
 using SurrealDb.Net.Models;

--- a/SurrealDb.Embedded.RocksDb/SurrealDb.Embedded.RocksDb.csproj
+++ b/SurrealDb.Embedded.RocksDb/SurrealDb.Embedded.RocksDb.csproj
@@ -30,7 +30,7 @@
     <Compile Include="..\SurrealDb.Net\Internals\Extensions\StringExtensions.cs" Link="Internals\Extensions\StringExtensions.cs" />
     <Compile Include="..\SurrealDb.Net\Internals\Extensions\SurrealDbLoggerExtensions.cs" Link="Internals\Extensions\SurrealDbLoggerExtensions.cs" />
     <Compile Include="..\SurrealDb.Net\Internals\Stream\MemoryStreamProvider.cs" Link="Internals\Stream\MemoryStreamProvider.cs" />
-    <Compile Include="..\SurrealDb.Net\Internals\Helpers\CborDebugHelper.cs" Link="Internals\Helpers\CborDebugHelper.cs" />
+    <Compile Include="..\SurrealDb.Net\Internals\Cbor\CborDebugHelper.cs" Link="Internals\Cbor\CborDebugHelper.cs" />
     <Compile Include="..\SurrealDb.Net\Internals\Sessions\SessionInfo.cs" Link="Internals\Sessions\SessionInfo.cs" />
   </ItemGroup>
 

--- a/SurrealDb.Embedded.SurrealKv/SurrealDb.Embedded.SurrealKv.csproj
+++ b/SurrealDb.Embedded.SurrealKv/SurrealDb.Embedded.SurrealKv.csproj
@@ -30,7 +30,7 @@
     <Compile Include="..\SurrealDb.Net\Internals\Extensions\StringExtensions.cs" Link="Internals\Extensions\StringExtensions.cs" />
     <Compile Include="..\SurrealDb.Net\Internals\Extensions\SurrealDbLoggerExtensions.cs" Link="Internals\Extensions\SurrealDbLoggerExtensions.cs" />
     <Compile Include="..\SurrealDb.Net\Internals\Stream\MemoryStreamProvider.cs" Link="Internals\Stream\MemoryStreamProvider.cs" />
-    <Compile Include="..\SurrealDb.Net\Internals\Helpers\CborDebugHelper.cs" Link="Internals\Helpers\CborDebugHelper.cs" />
+    <Compile Include="..\SurrealDb.Net\Internals\Cbor\CborDebugHelper.cs" Link="Internals\Cbor\CborDebugHelper.cs" />
     <Compile Include="..\SurrealDb.Net\Internals\Sessions\SessionInfo.cs" Link="Internals\Sessions\SessionInfo.cs" />
   </ItemGroup>
 

--- a/SurrealDb.Net/Internals/Cbor/CborDebugHelper.cs
+++ b/SurrealDb.Net/Internals/Cbor/CborDebugHelper.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text;
 
-namespace SurrealDb.Net.Internals.Helpers;
+namespace SurrealDb.Net.Internals.Cbor;
 
 internal static class CborDebugHelper
 {


### PR DESCRIPTION
## What changed

`CborDebugHelper` (an `internal static class` with CBOR-to-hex debug-dump helpers) lived in `SurrealDb.Net/Internals/Helpers/`, isolated from the rest of the CBOR-related code in `SurrealDb.Net/Internals/Cbor/`. This PR moves it there via `git mv` and updates its namespace from `SurrealDb.Net.Internals.Helpers` to `SurrealDb.Net.Internals.Cbor` to match the folder convention (confirmed against `SurrealDb.Net/Internals/Cbor/SurrealDbCborOptions.cs`).

Call sites updated accordingly:
- `SurrealDb.Embedded.Internals/SurrealDbEmbeddedEngine.cs` — dropped the now-unused `using SurrealDb.Net.Internals.Helpers;` (it already had `using SurrealDb.Net.Internals.Cbor;`).
- `SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs` and `SurrealDb.Net/Internals/SurrealDbEngine.Http.cs` — no `using` changes needed; both already import `SurrealDb.Net.Internals.Cbor` and still use other helpers from `Internals.Helpers` (`RandomHelper`, `HttpClientHelper`), so that using directive stays.
- `SurrealDb.Embedded.RocksDb`, `SurrealDb.Embedded.InMemory`, `SurrealDb.Embedded.SurrealKv`, `SurrealDb.Embedded.Internals` `.csproj` files — updated the linked `<Compile Include>`/`Link` paths that referenced the file by its old location.

## Why

This consolidates all CBOR-related code into one folder ahead of a planned CBOR/JSON debug-visibility feature (driven by community feedback that CBOR payloads are opaque and hard to debug). Landing this tidy-up first means that future feature reads as a clean addition to `Internals/Cbor` instead of being tangled with a file-move.

## Scope

Purely mechanical: no behavior change. `CborDebugHelper` is `internal` (not public) both before and after, so there is no public API surface impact.

## Verification

- `dotnet build` on the full solution: 0 warnings, 0 errors.
- `dotnet run --project SurrealDb.Net.Tests.csproj -- --treenode-filter "/*/*Cbor*/*/*"`: 97/97 CBOR serializer tests passing.
- Grepped the whole repo for `CborDebugHelper` / `Internals.Helpers` references to confirm every call site and csproj link was updated, and none were missed.