### PR TITLE
fix(deps): resolve RUSTSEC advisories in rust-embedded dependency tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,3 +309,4 @@ Note that the support for .NET standard 2.1 will be maintained until further not
 
 - [Contributing guidelines](./CONTRIBUTING.md)
 - [Setup the project for contributions](./GET_STARTED.md)
+

--- a/README.md
+++ b/README.md
@@ -309,4 +309,3 @@ Note that the support for .NET standard 2.1 will be maintained until further not
 
 - [Contributing guidelines](./CONTRIBUTING.md)
 - [Setup the project for contributions](./GET_STARTED.md)
-

--- a/deny.toml
+++ b/deny.toml
@@ -55,10 +55,17 @@ yanked = "warn"
 # A list of security advisory identifiers to ignore.
 # TODOs:
 # - for RUSTSEC-2025-0141, `bincode` is pulled transitively via `surrealmx`/`surrealdb-core`.
-#   No safe upgrade is available according to RustSec at this time.
-# - for RUSTSEC-2023-0071, `rsa` is pulled transitively via `jsonwebtoken`/`surrealdb-core`.
-#   No safe upgrade is available according to RustSec at this time.
-ignore = ["RUSTSEC-2025-0141", "RUSTSEC-2023-0071"]
+#   Unmaintained-crate advisory: development ceased permanently, so no patched version
+#   will ever exist. Resolving it requires `surrealmx` to migrate off bincode upstream.
+# - for RUSTSEC-2023-0071 (Marvin Attack), `rsa` is pulled transitively via
+#   `jsonwebtoken`/`surrealdb-core`. No patched stable release exists; the constant-time
+#   rewrite is only available as 0.10.0 release candidates, which jsonwebtoken's
+#   `rsa ^0.9` requirement cannot reach. Re-check once rsa 0.10.0 ships stable.
+# - for RUSTSEC-2023-0089, `atomic-polyfill` is unmaintained with no replacement release.
+#   It is pulled into Cargo.lock via `geo-types` legacy rstar compat features
+#   (rstar 0.9-0.11 -> heapless 0.7), which are never enabled in this build, so the
+#   crate is not actually compiled. Goes away once upstream drops rstar <0.12 support.
+ignore = ["RUSTSEC-2025-0141", "RUSTSEC-2023-0071", "RUSTSEC-2023-0089"]
 
 # --------------------------------------------------
 # LICENSES

--- a/rust-embedded/Cargo.lock
+++ b/rust-embedded/Cargo.lock
@@ -697,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/rust-embedded/Cargo.lock
+++ b/rust-embedded/Cargo.lock
@@ -1299,7 +1299,7 @@ dependencies = [
  "i_overlay",
  "log",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "robust",
  "rstar 0.12.2",
  "serde",
@@ -1973,7 +1973,7 @@ dependencies = [
  "p256",
  "p384",
  "pem",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
@@ -2193,7 +2193,7 @@ dependencies = [
  "noisy_float",
  "num-integer",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2260,7 +2260,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -2792,9 +2792,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2803,9 +2803,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3180,7 +3180,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
@@ -3633,7 +3633,7 @@ dependencies = [
  "pin-project-lite",
  "quick_cache",
  "radix_trie",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "reblessive",
  "regex",
@@ -3735,7 +3735,7 @@ dependencies = [
  "hex",
  "http",
  "papaya",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "rstest",
  "rust_decimal",
@@ -3779,7 +3779,7 @@ dependencies = [
  "lz4_flex",
  "parking_lot",
  "quick_cache",
- "rand 0.9.2",
+ "rand 0.9.3",
  "scopeguard",
  "sha2",
  "snap",
@@ -4232,7 +4232,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.3",
  "serde",
  "web-time",
 ]

--- a/rust-embedded/Cargo.lock
+++ b/rust-embedded/Cargo.lock
@@ -214,9 +214,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -225,14 +225,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]

--- a/rust-embedded/Cargo.lock
+++ b/rust-embedded/Cargo.lock
@@ -67,14 +67,13 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ammonia"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e913097e1a2124b46746c980134e8c954bc17a6a59bb3fde96f088d126dde6"
+checksum = "68b9d3370580a12f4b7a10fdcc18b28942c083ba570e3d954fe59d10951b85a2"
 dependencies = [
  "cssparser",
  "html5ever",
  "maplit",
- "tendril",
  "url",
 ]
 
@@ -769,25 +768,13 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.35.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
 dependencies = [
- "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.11.3",
  "smallvec",
-]
-
-[[package]]
-name = "cssparser-macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
-dependencies = [
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]
@@ -1146,16 +1133,6 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
-name = "futf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
-dependencies = [
- "mac",
- "new_debug_unreachable",
-]
 
 [[package]]
 name = "futures"
@@ -1604,13 +1581,12 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.35.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
 dependencies = [
  "log",
  "markup5ever",
- "match_token",
 ]
 
 [[package]]
@@ -2118,12 +2094,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-
-[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2131,24 +2101,13 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markup5ever"
-version = "0.35.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
  "tendril",
  "web_atoms",
-]
-
-[[package]]
-name = "match_token"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]
@@ -2534,43 +2493,23 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros 0.13.1",
- "phf_shared 0.13.1",
+ "phf_macros",
+ "phf_shared",
  "serde",
 ]
 
 [[package]]
 name = "phf_codegen"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.5",
+ "phf_generator",
+ "phf_shared",
 ]
 
 [[package]]
@@ -2580,20 +2519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
+ "phf_shared",
 ]
 
 [[package]]
@@ -2602,21 +2528,12 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
  "unicase",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -3607,25 +3524,24 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.8.9"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared 0.11.3",
+ "phf_shared",
  "precomputed-hash",
- "serde",
 ]
 
 [[package]]
 name = "string_cache_codegen"
-version = "0.5.4"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
 ]
@@ -3712,7 +3628,7 @@ dependencies = [
  "parking_lot",
  "path-clean",
  "pbkdf2",
- "phf 0.13.1",
+ "phf",
  "pin-project-lite",
  "quick_cache",
  "radix_trie",
@@ -3965,13 +3881,11 @@ dependencies = [
 
 [[package]]
 name = "tendril"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
 dependencies = [
- "futf",
- "mac",
- "utf-8",
+ "new_debug_unreachable",
 ]
 
 [[package]]
@@ -4377,12 +4291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4595,11 +4503,11 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.1.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
 dependencies = [
- "phf 0.11.3",
+ "phf",
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",

--- a/rust-embedded/Cargo.lock
+++ b/rust-embedded/Cargo.lock
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"


### PR DESCRIPTION
# Fix RUSTSEC advisories in the rust-embedded dependency tree

This PR remediates 12 RustSec/OSV advisories reported against `rust-embedded/Cargo.lock`, one commit per advisory (or advisory group sharing a single dependency chain). All changes are lock-file-only — no `Cargo.toml` requirements needed to change.

## Fixed via dependency updates

| Advisory | Crate | Before | After | Issue |
|---|---|---|---|---|
| [RUSTSEC-2026-0193](https://osv.dev/RUSTSEC-2026-0193) | `ammonia` | 4.1.2 | 4.1.3 | mXSS via MathML `annotation-xml` encoding strip |
| [RUSTSEC-2026-0190](https://osv.dev/RUSTSEC-2026-0190) | `anyhow` | 1.0.101 | 1.0.103 | Unsound `Error::downcast_mut()` after `context()` (UB) |
| [RUSTSEC-2026-0044](https://osv.dev/RUSTSEC-2026-0044) | `aws-lc-sys` | 0.37.1 | 0.42.0 | X.509 name constraints bypass via wildcard/Unicode CN |
| [RUSTSEC-2026-0045](https://osv.dev/RUSTSEC-2026-0045) | `aws-lc-sys` | 0.37.1 | 0.42.0 | Timing side-channel in AES-CCM tag verification |
| [RUSTSEC-2026-0046](https://osv.dev/RUSTSEC-2026-0046) | `aws-lc-sys` | 0.37.1 | 0.42.0 | `PKCS7_verify` certificate chain validation bypass (CVSS 7.5) |
| [RUSTSEC-2026-0047](https://osv.dev/RUSTSEC-2026-0047) | `aws-lc-sys` | 0.37.1 | 0.42.0 | `PKCS7_verify` signature validation bypass (CVSS 7.5) |
| [RUSTSEC-2026-0048](https://osv.dev/RUSTSEC-2026-0048) | `aws-lc-sys` | 0.37.1 | 0.42.0 | CRL distribution point scope check logic error (CVSS 7.5) |
| [RUSTSEC-2026-0204](https://osv.dev/RUSTSEC-2026-0204) | `crossbeam-epoch` | 0.9.18 | 0.9.20 | Invalid pointer deref in `fmt::Pointer` for `Atomic`/`Shared` |
| [RUSTSEC-2026-0097](https://osv.dev/RUSTSEC-2026-0097) | `rand` | 0.8.5 / 0.9.2 | 0.8.6 / 0.9.3 | Unsound `ThreadRng` reseeding with a custom logger (UB) |

Note on the aws-lc group: `aws-lc-sys` could not be bumped directly because `aws-lc-rs` 1.16.0 pins `aws-lc-sys ^0.37.0`. Updating the parent `aws-lc-rs` 1.16.0 → 1.17.1 (within `jsonwebtoken`'s `^1.15.0` requirement) pulls `aws-lc-sys ^0.42.0`, which covers all five advisories in one change.

## No fix available — documented in `deny.toml`

| Advisory | Crate | Status |
|---|---|---|
| [RUSTSEC-2025-0141](https://osv.dev/RUSTSEC-2025-0141) | `bincode` 2.0.1 | Unmaintained (development permanently ceased); no patched version will ever exist. Pulled via `surrealmx`/`surrealdb-core`; requires surrealmx to migrate off bincode upstream. Ignore kept, comment updated. |
| [RUSTSEC-2023-0071](https://osv.dev/RUSTSEC-2023-0071) | `rsa` 0.9.10 | Marvin timing attack; no patched **stable** release exists (fix only in 0.10.0-rc.x, unreachable from `jsonwebtoken`'s `rsa ^0.9`). Practical exposure is low: this tree uses RSA for JWT verification (public-key ops). Ignore kept, comment updated. |
| [RUSTSEC-2023-0089](https://osv.dev/RUSTSEC-2023-0089) | `atomic-polyfill` 1.0.3 | Unmaintained; no replacement release. Present in `Cargo.lock` only via never-enabled `geo-types` legacy rstar (0.9–0.11) compat features → `heapless 0.7`, so it is not actually compiled (cargo-deny's feature-resolved graph doesn't even see it — flagged only by raw lock scanners). New ignore added with explanation. |

## Validation

- `cargo deny check advisories` (repo-root `deny.toml`): **`advisories ok`** — down from 10 errors on `main`. The single remaining warning is `advisory-not-detected` for RUSTSEC-2023-0089, expected per the note above.
- `cargo check --workspace` in `rust-embedded/`: passes with the updated lock file (includes the native `aws-lc-sys` 0.42.0 build and ammonia's `html5ever` 0.35 → 0.39 transitive jump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
