### PR TITLE
fix(ci): fall back to ubuntu-latest runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
       - "**.md"
 jobs:
   build-remote:
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -40,7 +40,7 @@ jobs:
 
   build:
     needs: [embedded-build]
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -72,7 +72,7 @@ jobs:
 
   test:
     needs: [embedded-build]
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         surrealdb_version:
@@ -146,7 +146,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   embedded-build:
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
 
   create-package:
     needs: [embedded-builds]
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -193,7 +193,7 @@ jobs:
 
   validate-package:
     needs: [create-package]
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
 
     steps:
       - name: Setup dotnet 10.0


### PR DESCRIPTION
## Summary
- The `ubuntu-latest-4-cores` GitHub-hosted larger-runner pool has stopped picking up jobs org-wide. Queued jobs sit unassigned (`runner_id: 0`) and get auto-cancelled by GitHub after the 24h queued-job timeout (observed on #254, #255, and currently on #256's `build-remote`/`embedded-build`).
- This blocks `build-remote`, `build`, `test`, and `embedded-build` in `ci.yml` on every open PR, and the equivalent jobs in `release.yml`.
- Last successful run on this label was #249 (2026-05-11); jobs on plain `ubuntu-latest` (e.g. `cargo-check`) are running fine right now, confirming it's isolated to the larger-runner label.

Swapping `runs-on: ubuntu-latest-4-cores` → `runs-on: ubuntu-latest` in both workflows unblocks CI immediately. This is a stopgap — the larger-runner pool itself needs to be restored at the org level (GitHub org Settings → Actions → Runners), which likely needs someone with org admin access to investigate (billing/quota/config).