### PR TITLE
fix(ws): handle NONE session in responses and keep WS receive loop alive

### DIFF
--- a/SurrealDb.Net.Tests/Serializers/Cbor/SurrealDbWsResponseConverterTests.cs
+++ b/SurrealDb.Net.Tests/Serializers/Cbor/SurrealDbWsResponseConverterTests.cs
@@ -1,5 +1,6 @@
 ﻿using SurrealDb.Net.Internals.Cbor;
 using SurrealDb.Net.Internals.Ws;
+using SurrealDb.Net.Models;
 using SurrealDb.Net.Models.Response;
 
 namespace SurrealDb.Net.Tests.Serializers.Cbor;
@@ -111,5 +112,97 @@ public class SurrealDbWsResponseConverterTests : BaseCborConverterTests
         errorResponse
             .Error.Message.Should()
             .Be("There was a problem with the database: The signup query failed");
+    }
+
+    /// <summary>
+    /// Regression test for the exact KILLED live query notification sent by SurrealDB 3.x,
+    /// where "record", "result" and "session" are all NONE (tag 6 + null).
+    /// A failure to deserialize this notification used to terminate the WS receive pipeline,
+    /// causing every subsequent request on the connection to end up in timeout.
+    /// </summary>
+    [Test]
+    public async Task DeserializeWsLiveKilledNotificationFromSurrealDbV3()
+    {
+        // CBOR (captured from a SurrealDB 3.1.2 server):
+        // {
+        //   "result": {
+        //     "action": "KILLED",
+        //     "id": tag(37) h'4566a27276744e73889fbb936f416a22',
+        //     "record": tag(6) null,
+        //     "result": tag(6) null,
+        //     "session": tag(6) null
+        //   }
+        // }
+        var response = await DeserializeCborBinaryAsHexaAsync<ISurrealDbWsResponse>(
+            "a166726573756c74a566616374696f6e664b494c4c4544626964d825504566a27276744e73889fbb936f416a22667265636f7264c6f666726573756c74c6f66773657373696f6ec6f6"
+        );
+
+        response.Should().BeOfType<SurrealDbWsKilledResponse>();
+    }
+
+    [Test]
+    public async Task DeserializeWsLiveNotificationWithNoneSession()
+    {
+        // CBOR:
+        // {
+        //   "result": {
+        //     "action": "CREATE",
+        //     "id": tag(37) h'4566a27276744e73889fbb936f416a22',
+        //     "record": tag(8) ["post", "first"],
+        //     "result": { "name": "john" },
+        //     "session": tag(6) null
+        //   }
+        // }
+        var response = await DeserializeCborBinaryAsHexaAsync<ISurrealDbWsResponse>(
+            "a166726573756c74a566616374696f6e66435245415445626964d825504566a27276744e73889fbb936f416a22667265636f7264c88264706f737465666972737466726573756c74a1646e616d65646a6f686e6773657373696f6ec6f6"
+        );
+
+        response.Should().BeOfType<SurrealDbWsLiveResponse>();
+
+        var liveResponse = (SurrealDbWsLiveResponse)response;
+
+        liveResponse.Result.Id.Should().Be(Guid.Parse("4566a272-7674-4e73-889f-bb936f416a22"));
+        liveResponse.Result.Action.Should().Be("CREATE");
+        liveResponse.Result.Record.Should().Be(new RecordIdOfString("post", "first"));
+    }
+
+    [Test]
+    public async Task DeserializeWsResponseWithSession()
+    {
+        // CBOR:
+        // {
+        //   "id": "12345678",
+        //   "result": tag(6) null,
+        //   "session": tag(37) h'4566a27276744e73889fbb936f416a22'
+        // }
+        var response = await DeserializeCborBinaryAsHexaAsync<ISurrealDbWsResponse>(
+            "a362696468313233343536373866726573756c74c6f66773657373696f6ed825504566a27276744e73889fbb936f416a22"
+        );
+
+        response.Should().BeOfType<SurrealDbWsOkResponse>();
+
+        var okResponse = (SurrealDbWsOkResponse)response;
+
+        okResponse.Id.Should().Be("12345678");
+    }
+
+    [Test]
+    public async Task DeserializeWsResponseWithNoneSession()
+    {
+        // CBOR:
+        // {
+        //   "id": "12345678",
+        //   "result": tag(6) null,
+        //   "session": tag(6) null
+        // }
+        var response = await DeserializeCborBinaryAsHexaAsync<ISurrealDbWsResponse>(
+            "a362696468313233343536373866726573756c74c6f66773657373696f6ec6f6"
+        );
+
+        response.Should().BeOfType<SurrealDbWsOkResponse>();
+
+        var okResponse = (SurrealDbWsOkResponse)response;
+
+        okResponse.Id.Should().Be("12345678");
     }
 }

--- a/SurrealDb.Net/Internals/Cbor/Converters/SurrealDbWsLiveResponseContentConverter.cs
+++ b/SurrealDb.Net/Internals/Cbor/Converters/SurrealDbWsLiveResponseContentConverter.cs
@@ -40,9 +40,6 @@ internal sealed class SurrealDbWsLiveResponseContentConverter
         {
             ReadOnlySpan<byte> key = reader.ReadRawString();
 
-            if (key.IsEmpty)
-                continue;
-
             if (key.SequenceEqual("id"u8))
             {
                 id = _guidConverter.Read(ref reader);
@@ -69,7 +66,15 @@ internal sealed class SurrealDbWsLiveResponseContentConverter
 
             if (key.SequenceEqual("session"u8))
             {
-                session = _guidConverter.Read(ref reader);
+                if (reader.GetCurrentDataItemType() == CborDataItemType.Null)
+                {
+                    reader.ReadNull();
+                    session = null;
+                }
+                else
+                {
+                    session = _guidConverter.Read(ref reader);
+                }
                 continue;
             }
 

--- a/SurrealDb.Net/Internals/Cbor/Converters/SurrealDbWsResponseConverter.cs
+++ b/SurrealDb.Net/Internals/Cbor/Converters/SurrealDbWsResponseConverter.cs
@@ -66,7 +66,15 @@ internal sealed class SurrealDbWsResponseConverter : CborConverterBase<ISurrealD
 
             if (key.SequenceEqual("session"u8))
             {
-                session = _guidConverter.Read(ref reader);
+                if (reader.GetCurrentDataItemType() == CborDataItemType.Null)
+                {
+                    reader.ReadNull();
+                    session = null;
+                }
+                else
+                {
+                    session = _guidConverter.Read(ref reader);
+                }
                 continue;
             }
 

--- a/SurrealDb.Net/Internals/Extensions/SurrealDbLoggerExtensions.cs
+++ b/SurrealDb.Net/Internals/Extensions/SurrealDbLoggerExtensions.cs
@@ -118,6 +118,15 @@ internal static partial class SurrealDbLoggerExtensions
         string executionTime
     );
 
+    [LoggerMessage(
+        Level = LogLevel.Error,
+        Message = "Failed to process a message received from the server. The message was skipped."
+    )]
+    public static partial void LogReceivedMessageProcessingFailed(
+        this ILogger logger,
+        Exception exception
+    );
+
     [LoggerMessage(Level = LogLevel.Debug, Message = "CBOR data serialized: {data}")]
     public static partial void LogSerializationDataSerialized(this ILogger logger, string data);
 

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
@@ -164,102 +164,111 @@ internal sealed class SurrealDbWsEngine : ISurrealDbEngine
                 Observable.FromAsync(
                     async (cancellationToken) =>
                     {
-#if DEBUG
+                        // 💡 A failure to process a single message (e.g. an unexpected CBOR payload)
+                        // must not terminate the underlying Rx subscription,
+                        // otherwise all subsequent responses would be silently dropped
+                        // and every pending request would end up in timeout.
                         try
                         {
-#endif
-                        ISurrealDbWsResponse? response = null;
+                            ISurrealDbWsResponse? response = null;
 
-                        if (message.MessageType == WebSocketMessageType.Binary)
-                        {
-                            using var stream =
-                                message.Stream
-                                ?? MemoryStreamProvider.MemoryStreamManager.GetStream(
-                                    message.Binary!
-                                );
-
-                            if (
-                                _surrealDbLoggerFactory?.Serialization?.IsEnabled(LogLevel.Debug)
-                                == true
-                            )
+                            if (message.MessageType == WebSocketMessageType.Binary)
                             {
-                                string cborData = CborDebugHelper.CborBinaryToHexa(stream);
-                                _surrealDbLoggerFactory?.Serialization?.LogSerializationDataDeserialized(
-                                    cborData
-                                );
-                            }
+                                using var stream =
+                                    message.Stream
+                                    ?? MemoryStreamProvider.MemoryStreamManager.GetStream(
+                                        message.Binary!
+                                    );
 
-                            response = await CborSerializer
-                                .DeserializeAsync<ISurrealDbWsResponse>(
-                                    stream,
-                                    GetCborOptions(),
-                                    cancellationToken
+                                if (
+                                    _surrealDbLoggerFactory?.Serialization?.IsEnabled(
+                                        LogLevel.Debug
+                                    ) == true
                                 )
-                                .ConfigureAwait(false);
-                        }
-
-                        if (response is SurrealDbWsLiveResponse surrealDbWsLiveResponse)
-                        {
-                            var liveQueryUuid = surrealDbWsLiveResponse.Result.Id;
-
-                            if (
-                                _liveQueryChannelSubscriptionsPerQuery.TryGetValue(
-                                    liveQueryUuid,
-                                    out var liveQueryChannelSubscriptions
-                                )
-                            )
-                            {
-                                var tasks = liveQueryChannelSubscriptions.Select(liveQueryChannel =>
                                 {
-                                    return liveQueryChannel.WriteAsync(surrealDbWsLiveResponse);
-                                });
+                                    string cborData = CborDebugHelper.CborBinaryToHexa(stream);
+                                    _surrealDbLoggerFactory?.Serialization?.LogSerializationDataDeserialized(
+                                        cborData
+                                    );
+                                }
 
-                                await Task.WhenAll(tasks).ConfigureAwait(false);
+                                response = await CborSerializer
+                                    .DeserializeAsync<ISurrealDbWsResponse>(
+                                        stream,
+                                        GetCborOptions(),
+                                        cancellationToken
+                                    )
+                                    .ConfigureAwait(false);
                             }
 
-                            return;
-                        }
-
-                        if (
-                            response is ISurrealDbWsStandardResponse surrealDbWsStandardResponse
-#if NET9_0_OR_GREATER
-                            && _responseTasks.TryRemove(
-                                surrealDbWsStandardResponse.Id,
-                                out var responseTaskCompletionSource
-                            )
-#else
-                            && _responseTaskHandler.TryRemove(
-                                surrealDbWsStandardResponse.Id,
-                                out var responseTaskCompletionSource
-                            )
-#endif
-                        )
-                        {
-                            switch (response)
+                            if (response is SurrealDbWsLiveResponse surrealDbWsLiveResponse)
                             {
-                                case SurrealDbWsOkResponse okResponse:
-                                    responseTaskCompletionSource.SetResult(okResponse);
-                                    break;
-                                case SurrealDbWsErrorResponse errorResponse:
-                                    responseTaskCompletionSource.SetException(
-                                        errorResponse.Error.ToException()
+                                var liveQueryUuid = surrealDbWsLiveResponse.Result.Id;
+
+                                if (
+                                    _liveQueryChannelSubscriptionsPerQuery.TryGetValue(
+                                        liveQueryUuid,
+                                        out var liveQueryChannelSubscriptions
+                                    )
+                                )
+                                {
+                                    var tasks = liveQueryChannelSubscriptions.Select(
+                                        liveQueryChannel =>
+                                        {
+                                            return liveQueryChannel.WriteAsync(
+                                                surrealDbWsLiveResponse
+                                            );
+                                        }
                                     );
-                                    break;
-                                default:
-                                    responseTaskCompletionSource.SetException(
-                                        new UnknownResponseTypeException()
-                                    );
-                                    break;
+
+                                    await Task.WhenAll(tasks).ConfigureAwait(false);
+                                }
+
+                                return;
                             }
-                        }
-#if DEBUG
+
+                            if (
+                                response is ISurrealDbWsStandardResponse surrealDbWsStandardResponse
+#if NET9_0_OR_GREATER
+                                && _responseTasks.TryRemove(
+                                    surrealDbWsStandardResponse.Id,
+                                    out var responseTaskCompletionSource
+                                )
+#else
+                                && _responseTaskHandler.TryRemove(
+                                    surrealDbWsStandardResponse.Id,
+                                    out var responseTaskCompletionSource
+                                )
+#endif
+                            )
+                            {
+                                switch (response)
+                                {
+                                    case SurrealDbWsOkResponse okResponse:
+                                        responseTaskCompletionSource.SetResult(okResponse);
+                                        break;
+                                    case SurrealDbWsErrorResponse errorResponse:
+                                        responseTaskCompletionSource.SetException(
+                                            errorResponse.Error.ToException()
+                                        );
+                                        break;
+                                    default:
+                                        responseTaskCompletionSource.SetException(
+                                            new UnknownResponseTypeException()
+                                        );
+                                        break;
+                                }
+                            }
                         }
                         catch (Exception ex)
                         {
+#if DEBUG
                             Debug.WriteLine(ex.Message);
-                            throw;
-                        }
 #endif
+                            _surrealDbLoggerFactory?.Connection?.LogReceivedMessageProcessingFailed(
+                                ex
+                            );
+                        }
                     }
                 )
             )


### PR DESCRIPTION
## What's the problem?

The `test (v3.0.5)` and `test (v3.1.2)` CI jobs consistently fail on the **Test Live Query feature** step (currently blocking #253 and #254, and failing on `main` itself — e.g. runs [29090984186](https://github.com/surrealdb/surrealdb.net/actions/runs/29090984186) and [29090969723](https://github.com/surrealdb/surrealdb.net/actions/runs/29090969723)). Always the same 2 tests:

- `ShouldAutomaticallyKillLiveQueryWhenDisposed`
- `ShouldManuallyKillLiveQuery`

Both expect a `SurrealDbException` when killing an already-killed live query, but instead get a `System.TimeoutException` after 30s.

## Root cause

SurrealDB **3.x** sends a `KILLED` live query notification where `record`, `result` **and `session`** are all `NONE` (CBOR tag 6 + null). Captured from a 3.1.2 server:

```
{
  "result": {
    "action": "KILLED",
    "id": tag(37) h'...uuid...',
    "record": tag(6) null,
    "result": tag(6) null,
    "session": tag(6) null
  }
}
```

`SurrealDbWsLiveResponseContentConverter` reads `session` with the `Guid` converter, which throws `CborException` on a tagged null. The WS receive pipeline (`MessageReceived … .Select(Observable.FromAsync(...)).Merge().Subscribe()`) had **no error handling**, so that single exception terminated the whole Rx subscription. From that point on, every response on the connection was silently dropped and every pending request (the second `kill`, pings, everything) failed with a 30s timeout. That's why the tests observed `TimeoutException` instead of the expected server error — and only on 3.x, since 2.x doesn't produce this notification shape. `ShouldFailToKillInexistantLiveQueryOnWsProtocol` (no prior live query → no notification) kept passing, which pinpointed the notification as the trigger.

### Why did this only start failing now?

These same server versions were green until June 12. Before #235, the `RecordId` converter left the null payload of `record: NONE` unconsumed; the stray `f6` byte was then swallowed as an *empty map key* by the `if (key.IsEmpty) continue;` guard (introduced in #195), and the off-by-one meant `session` was **never actually read**. So parsing only worked by accident. #235 correctly consumes the null, so the map cursor now reaches `session: NONE` → crash. The regression window (June 12 → July 10) was invisible because the runner outage cancelled all test runs until #257 fixed it.

## The fix

- Read `session` as null when the data item is (tagged) null, in both `SurrealDbWsResponseConverter` and `SurrealDbWsLiveResponseContentConverter` (same pattern as the existing `cause` handling in `RpcErrorResponseContentConverter`)
- Remove the empty-key band-aid from #195 that masked the misalignment
- **Harden the WS receive loop**: wrap the per-message handler in a try/catch (all configurations, not just `DEBUG`) and log via the existing logger factory, so a single unprocessable message can never terminate the subscription and brick the connection again. Any future protocol drift degrades to a logged error + one failed request instead of silent 30s timeouts for everything afterwards. (Follow-up idea, not in this PR: skipping unknown map keys instead of throwing in the response converters would make the client forward-compatible with new server fields, like `session` once was.)

## Tests

- New regression tests in `SurrealDbWsResponseConverterTests` including the **byte-exact KILLED notification captured from a 3.1.2 server** (fail without the converter fix, pass with it)
- Full `SurrealDb.Net.LiveQuery.Tests` suite run locally against **v3.1.2**, **v3.0.5** (previously failing: now 28 passed / 1 skipped) and **v2.6.1** (no regression)
- All 100 serializer unit tests pass; `dotnet csharpier --check` clean

## Related issues & PRs (triage after this fix)

This bug is user-facing beyond CI: verified that on current `main` against SurrealDB **v3.2.0** (latest), disposing/killing a live query bricks the WS connection and every subsequent request times out — fixed by this PR. While investigating, I went through the open issues/PRs of the same tagged-null/misalignment family and re-tested each against current `main` + SurrealDB v3.1.2 and v3.2.0:

| Item | Relation | Status |
|---|---|---|
| #234 (tuple loses element after tagged NONE/RecordId) | Same root cause family | **Fixed by #235 (merged), with regression tests — issue can be closed** |
| #227 (`SurrealDbResultConverter` crashes on empty `type` string) | Same family, reported against the released 0.9.0 package | **No longer reproduces** on `main` (v3 sends `type: NONE`, read as null and skipped). Fixed by the earlier v3-handling work (#222) + #235. Can be closed; resolved for package users at the next release |
| #236 (deserialization fails on WS `query`/`result`, `'' is not a valid result type`) | Duplicate symptom of #227 (0.9.0 package) | **No longer reproduces** on `main` — ran the issue's repro (`RETURN 1`, `DEFINE TABLE`, multi-statement queries) against v3.1.2 and v3.2.0: all pass. Can be closed |
| #254 (add `IsNullOrWhiteSpace` guard on `type`) | Defensive guard for #227 | The empty-string `type` was an artifact of the reader misalignment, which cannot occur anymore with a correctly positioned cursor — the guard is now unreachable. **Can be closed** (or kept as pure defense-in-depth) |
| #245 (GuidConverter: support `tag(37, tstr)` UUIDs) | Likely the same misalignment observed through a different lens | Byte captures from real v3.1.2 **and** v3.2.0 servers show UUIDs are still `tag(37) + bstr(16)` (e.g. `d8 25 50 ...`), so the premise (v3 switched to text-string UUIDs) doesn't match observed protocol data. The `"[1] Expected major type ByteString (2)"` error it works around is the classic symptom of a cursor left misaligned by an unconsumed tagged null — which this PR fixes at the source. **Likely superseded**; suggest the author re-tests on top of this fix before closing |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
