### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
 
     <IsPackable>false</IsPackable>
-    <Version>0.10.3</Version>
+    <Version>1.0.0</Version>
     <Authors>surrealdb</Authors>
     <Company>SurrealDB</Company>
     <Copyright>Copyright © SurrealDB Ltd</Copyright>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
 
     <IsPackable>false</IsPackable>
-    <Version>0.10.2</Version>
+    <Version>0.10.3</Version>
     <Authors>surrealdb</Authors>
     <Company>SurrealDB</Company>
     <Copyright>Copyright © SurrealDB Ltd</Copyright>


### PR DESCRIPTION
## Summary
Version bump to **1.0.0**, covering 6 changes merged to `main` since 0.10.2:

- #256 — `fix(deps)`: resolve RUSTSEC advisories in rust-embedded dependency tree
- #257 — `fix(ci)`: fall back to ubuntu-latest runners
- #252 — `fix`: pin Microsoft.OpenApi to patched version to fix CI restore failure
- #258 — `fix(ws)`: handle NONE session in responses and keep WS receive loop alive
- #254 — `fix`: crash on empty/whitespace `type` field in CBOR result deserialization
- #260 — `fix`: avoid duplicate `id`/`Id` field on `IRecord` direct implementers (internal CBOR mapping fix, no public API change)

All six are fixes with no breaking API changes. Target version updated to **1.0.0** (first stable release) per updated guidance, superseding the earlier 0.10.3 patch-bump plan.

## Changes
- `Directory.Build.props`: `Version` `0.10.2` → `1.0.0`

## Test plan
- [x] No functional code changes; version metadata only
- [ ] Maintainer to cut the GitHub Release (triggers `release.yml` → NuGet publish) after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)