### PR TITLE
fix: avoid duplicate id field on IRecord

### DIFF
--- a/SurrealDb.Net.Tests/CreateTests.cs
+++ b/SurrealDb.Net.Tests/CreateTests.cs
@@ -1,6 +1,22 @@
 ﻿using System.Text;
+using SurrealDb.Net.Models.Response;
 
 namespace SurrealDb.Net.Tests;
+
+/// <summary>
+/// A record type that implements <see cref="IRecord"/> directly (as opposed to inheriting
+/// <see cref="Record"/>) and does NOT redeclare the <c>[CborProperty("id")]</c> /
+/// <c>[CborIgnoreIfDefault]</c> attributes carried by <see cref="IRecord.Id"/>. This mirrors the
+/// scenario reported in https://github.com/surrealdb/surrealdb.net/issues/212, where such a class
+/// ends up with its <c>Id</c> serialized twice: once as the literal member name "Id" (riding
+/// along in the CBOR payload) and once as the RPC's own "id" positional argument.
+/// </summary>
+public class RawIdRecord : IRecord
+{
+    public RecordId? Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+}
 
 public class CreateTests
 {
@@ -206,5 +222,47 @@ public class CreateTests
         result!.Content.Should().Be("This is a new article created using the .NET SDK");
         result!.CreatedAt.Should().NotBeNull();
         result!.Status.Should().Be("DRAFT");
+    }
+
+    [Test]
+    [ConnectionStringFixtureGenerator]
+    public async Task ShouldCreateRecordImplementingIRecordDirectlyWithoutDuplicateIdField(
+        string connectionString
+    )
+    {
+        List<string>? fieldNames = null;
+
+        Func<Task> func = async () =>
+        {
+            await using var surrealDbClientGenerator = new SurrealDbClientGenerator();
+            var dbInfo = surrealDbClientGenerator.GenerateDatabaseInfo();
+
+            await using var client = surrealDbClientGenerator.Create(connectionString);
+            await client.Use(dbInfo.Namespace, dbInfo.Database);
+
+            var record = new RawIdRecord
+            {
+                Id = new RecordIdOfString("raw_id_record", "one"),
+                Name = "Alice",
+            };
+
+            await client.Create(record);
+
+            var response = await client.RawQuery(
+                "SELECT VALUE object::keys($this) FROM raw_id_record;"
+            );
+
+            var okResult = (SurrealDbOkResult)response[0];
+            fieldNames = okResult.GetValue<List<List<string>>>()!.Single();
+        };
+
+        await func.Should().NotThrowAsync();
+
+        fieldNames.Should().NotBeNull();
+        fieldNames!
+            .Count(fieldName => string.Equals(fieldName, "id", StringComparison.OrdinalIgnoreCase))
+            .Should()
+            .Be(1);
+        fieldNames.Should().NotContain("Id");
     }
 }

--- a/SurrealDb.Net/Internals/Cbor/Mappings/RecordIdObjectMappingConvention.cs
+++ b/SurrealDb.Net/Internals/Cbor/Mappings/RecordIdObjectMappingConvention.cs
@@ -1,0 +1,49 @@
+using System.Linq;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Serialization.Converters.Mappings;
+using SurrealDb.Net.Models;
+
+namespace SurrealDb.Net.Internals.Cbor.Mappings;
+
+/// <summary>
+/// Decorates another <see cref="IObjectMappingConvention"/> to guarantee that, for any concrete
+/// type implementing <see cref="IRecord"/>, the <c>Id</c> member is always serialized under the
+/// literal CBOR property name "id" and omitted from the payload when left unset.
+/// </summary>
+/// <remarks>
+/// C# does not propagate attributes declared on an interface member (here,
+/// <see cref="IRecord.Id"/>'s <c>[CborProperty("id")]</c> / <c>[CborIgnoreIfDefault]</c>) onto a
+/// class's own property when that property only implicitly implements the interface member.
+/// Without this convention, a class implementing <see cref="IRecord"/> directly (rather than
+/// inheriting <see cref="Record"/>) would have its <c>Id</c> property serialized under the
+/// literal member name "Id", riding along in the CBOR payload alongside the RPC's own "id"
+/// argument and producing a duplicate field on the server (see GitHub issue #212).
+/// </remarks>
+internal sealed class RecordIdObjectMappingConvention : IObjectMappingConvention
+{
+    private readonly IObjectMappingConvention _innerConvention;
+
+    public RecordIdObjectMappingConvention(IObjectMappingConvention innerConvention)
+    {
+        _innerConvention = innerConvention;
+    }
+
+    public void Apply<T>(SerializationRegistry registry, ObjectMapping<T> objectMapping)
+    {
+        _innerConvention.Apply(registry, objectMapping);
+
+        if (!typeof(IRecord).IsAssignableFrom(typeof(T)))
+        {
+            return;
+        }
+
+        var idMemberMapping = objectMapping
+            .MemberMappings.OfType<MemberMapping<T>>()
+            .FirstOrDefault(memberMapping =>
+                memberMapping.MemberInfo.Name == nameof(IRecord.Id)
+                && memberMapping.MemberType == typeof(RecordId)
+            );
+
+        idMemberMapping?.SetMemberName("id").SetIngoreIfDefault(true);
+    }
+}

--- a/SurrealDb.Net/Internals/Cbor/Mappings/RecordIdObjectMappingConventionProvider.cs
+++ b/SurrealDb.Net/Internals/Cbor/Mappings/RecordIdObjectMappingConventionProvider.cs
@@ -1,0 +1,26 @@
+using System;
+using Dahomey.Cbor.Serialization.Converters.Mappings;
+using SurrealDb.Net.Models;
+
+namespace SurrealDb.Net.Internals.Cbor.Mappings;
+
+/// <summary>
+/// Supplies a <see cref="RecordIdObjectMappingConvention"/> for every type implementing
+/// <see cref="IRecord"/>, so the CBOR representation of its <c>Id</c> member is always correct
+/// regardless of whether the concrete type redeclares the attributes carried by
+/// <see cref="IRecord.Id"/>.
+/// </summary>
+internal sealed class RecordIdObjectMappingConventionProvider : IObjectMappingConventionProvider
+{
+    private readonly DefaultObjectMappingConvention _defaultObjectMappingConvention = new();
+
+    public IObjectMappingConvention? GetConvention(Type type)
+    {
+        if (!typeof(IRecord).IsAssignableFrom(type))
+        {
+            return null;
+        }
+
+        return new RecordIdObjectMappingConvention(_defaultObjectMappingConvention);
+    }
+}

--- a/SurrealDb.Net/Internals/Cbor/SurrealDbCborOptions.cs
+++ b/SurrealDb.Net/Internals/Cbor/SurrealDbCborOptions.cs
@@ -2,6 +2,7 @@ using Dahomey.Cbor;
 using SurrealDb.Net.Internals.Cbor.Converters;
 using SurrealDb.Net.Internals.Cbor.Converters.Numerics;
 using SurrealDb.Net.Internals.Cbor.Converters.Spatial;
+using SurrealDb.Net.Internals.Cbor.Mappings;
 using SurrealDb.Net.Internals.Errors;
 using SurrealDb.Net.Internals.Http;
 using SurrealDb.Net.Internals.Ws;
@@ -20,6 +21,10 @@ public static class SurrealDbCborOptions
         {
             DefaultNamingConvention = new SurrealDbCborNamingConvention(),
         };
+
+        options.Registry.ObjectMappingConventionRegistry.RegisterProvider(
+            new RecordIdObjectMappingConventionProvider()
+        );
 
         options.Registry.ConverterRegistry.RegisterConverterProvider(
             new PrimitiveConverterProvider()


### PR DESCRIPTION
## Root cause

`IRecord.Id` carries `[CborProperty("id")]` and `[CborIgnoreIfDefault]`:

```csharp
public interface IRecord
{
    [JsonConverter(typeof(ReadOnlyRecordIdJsonConverter))]
    [CborProperty("id")]
    [CborIgnoreIfDefault]
    public RecordId? Id { get; set; }
}
```

C# does not propagate attributes declared on an interface member onto a class's own property when that property only *implicitly* implements the interface member. `Record` (the abstract base class most examples use) happens to redeclare those same attributes directly on its own `Id` property, so it's unaffected. But a class that implements `IRecord` directly — without inheriting `Record` — does **not** get those attributes, e.g.:

```csharp
public class MyRecord : IRecord
{
    public RecordId? Id { get; set; }   // no attributes carried over from IRecord.Id
}
```

Dahomey.Cbor's `MemberMapping<T>.InitializeMemberName()` resolves the CBOR name via `MemberInfo.GetCustomAttribute<CborPropertyAttribute>()`, and falls back to the naming convention (`SurrealDbCborNamingConvention`, which returns `member.Name` verbatim) when that attribute is absent. For `MyRecord`, this means `Id` is serialized under the literal name `"Id"`, and (since `[CborIgnoreIfDefault]` is also missing) it's never omitted.

`Create`/`Update`/`Upsert` (see `SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs` / `.Http.cs`) send `[data.Id, data]` — the id as its own RPC positional argument *and* the fully serialized `data` object. For direct `IRecord` implementers, that serialized object still contains the extra literal `"Id"` field, so the server persists both `id` and `Id` with the same value. Reproduced against a local SurrealDB 3.2 instance: `SELECT VALUE object::keys($this) FROM ...` returned `["Id", "id", "name"]` on `main`.

This is issue #212.

## Fix

Rather than asking every `IRecord` implementer to manually redeclare `[CborProperty("id")]` / `[CborIgnoreIfDefault]` (the workaround suggested on the issue — a caller-side patch that doesn't help existing or future callers who don't know to do it, and breaks Liskov substitutability between `IRecord` implementers and `Record` subclasses), this fixes the CBOR mapping layer directly:

- `SurrealDb.Net/Internals/Cbor/Mappings/RecordIdObjectMappingConventionProvider.cs`: a `Dahomey.Cbor` `IObjectMappingConventionProvider` that, for any type assignable to `IRecord`, supplies a decorating convention instead of the library's default one.
- `SurrealDb.Net/Internals/Cbor/Mappings/RecordIdObjectMappingConvention.cs`: the decorating `IObjectMappingConvention`. It runs the default convention first (normal attribute/naming-convention driven mapping), then locates the mapped member matching `IRecord.Id` (by name + type) and forces `MemberMapping.SetMemberName("id")` / `SetIngoreIfDefault(true)` on it — regardless of what attributes the concrete class did or didn't redeclare.
- `SurrealDb.Net/Internals/Cbor/SurrealDbCborOptions.cs`: registers the provider alongside the other CBOR registry configuration.

I considered stripping/renaming the `Id`/`id` property from the serialized content inside `Create`/`Update`/`Upsert` instead (option b in the issue investigation), but that would require re-inspecting/mutating the payload per call, on every codepath (WS and HTTP, for `Create`, `Update`, and `Upsert`, including the batch overloads), and would only band-aid the symptom rather than the actual naming-resolution gap. Fixing it once at the CBOR mapping-convention level covers every current and future call site for free, and is fully internal (`SurrealDb.Net.Internals.Cbor.Mappings`) — **no public API changes**, `IRecord` is untouched, and the fix is a no-op for existing `Record`-based types (their `Id` member is already named `"id"` and already ignored-if-default, so re-applying the same values is harmless).

## Regression test

Added `CreateTests.ShouldCreateRecordImplementingIRecordDirectlyWithoutDuplicateIdField`: defines `RawIdRecord : IRecord` (no attributes redeclared), creates a record through the public `Create<T>` API, then runs `SELECT VALUE object::keys($this) FROM raw_id_record;` against the server and asserts there is exactly one `id`-shaped field (case-insensitive) and that a literal `"Id"` field is absent.

Confirmed this test **fails on `main`** (both HTTP and WS transports) with `Expected ... to be 1, but found 2`, and **passes** after the fix.

## Verification

Run from the repo root of this worktree, against a local SurrealDB 3.2 instance:

- `dotnet tool restore` — ok
- `dotnet csharpier --check .` — `Formatted 486 files in 882ms` (no diffs)
- `dotnet build` (full solution, including the `rust-embedded` native providers built via `cargo build`) — `Build succeeded. 0 Warning(s). 0 Error(s).`
- Targeted regression test, via `dotnet run --project SurrealDb.Net.Tests.csproj --no-build -- --treenode-filter "/*/*/CreateTests/ShouldCreateRecordImplementingIRecordDirectlyWithoutDuplicateIdField*"` — 5/5 passed (http, ws, mem, rocksdb, surrealkv).

  Note: `dotnet test --filter ...` currently errors on this repo's TUnit/Microsoft.Testing.Platform setup under the .NET 10 SDK (`Testing with VSTest target is no longer supported ...`); this is pre-existing and unrelated to this change. `dotnet run --project ... -- --treenode-filter ...` is the mechanism this repo's own CI (`ci.yml`) uses to execute tests, so I used the equivalent for targeted runs.
- Full `SurrealDb.Net.Tests` suite: 1068 total, 1046 succeeded, 20 skipped (expected, feature/version gating), 2 failed — both failures (`AuthenticateTests.ShouldFailWhenInvalidate`, http+ws) are pre-existing and unrelated: the local instance wasn't started with `--allow-guests`, so anonymous access after `Invalidate()` correctly gets rejected by the server (`SurrealDbNotAllowedException: Anonymous access not allowed`), independent of this change.
- Full `SurrealDb.Net.LiveQuery.Tests` suite: 29 total, 24 succeeded, 1 skipped, 4 failed — same pre-existing `--allow-guests` environment gap, unrelated to this change.
- `CreateTests` suite in isolation: 30/30 passed.

Fixes #212