### PR TITLE
Use OIDC for NuGet package publishing instead of API key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,6 +215,8 @@ jobs:
   publish-package:
     needs: [validate-package]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
       - name: Setup dotnet 10.0
@@ -227,8 +229,14 @@ jobs:
           name: nuget
           path: ${{ env.NuGetDirectory }}
 
+      - name: NuGet login (OIDC -> temp API key)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Publish NuGet package
         run: |
           foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Recurse -Include *.nupkg)) {
-              dotnet nuget push $file --api-key "${{ secrets.NUGET_APIKEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+              dotnet nuget push $file --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
           }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

This change improves the security of the NuGet package publishing workflow by replacing static API key authentication with OpenID Connect (OIDC) token-based authentication. OIDC provides better security practices by using short-lived tokens instead of long-lived API keys, reducing the risk of credential exposure.

## What does this change do?

This pull request updates the `publish-package` job in the release workflow to:

1. Add the `id-token: write` permission required for OIDC token generation
2. Add a new step that uses the official NuGet login action to exchange the OIDC token for a temporary NuGet API key
3. Update the NuGet push command to use the temporary API key from the login step instead of the static `NUGET_APIKEY` secret

## What is your testing strategy?

The workflow changes will be validated when the next release is published. The CI/CD pipeline will verify that:
- The OIDC token exchange succeeds
- The temporary API key is correctly generated and passed to the NuGet push command
- The package is successfully published to nuget.org

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)