### PR TITLE
Pin NuGet/login action to a full commit SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,7 +230,7 @@ jobs:
           path: ${{ env.NuGetDirectory }}
 
       - name: NuGet login (OIDC -> temp API key)
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
         id: login
         with:
           user: ${{ secrets.NUGET_USER }}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The `v1.0.0` release run failed before it could publish to NuGet, because the `NuGet/login@v1` action added in #261 is not pinned to a commit SHA. This repository's Actions policy requires every action to be pinned to a full-length commit SHA, so the job was rejected before it could run.

## What does this change do?

Pins `NuGet/login` to its `v1` tag's commit SHA (`8d196754b4036150537f80ac539e15c2f1028841`), matching the pinning convention already used for every other action in `release.yml`.

## What is your testing strategy?

Verified the commit SHA against the `NuGet/login` repository's `v1` release page and the commit itself. The fix will be confirmed on the next release run, once a new release is created targeting a commit that includes this change.

## Is this related to any issues?

Follow-up to #261.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)