### PR TITLE
Fix embedded transaction UUID byte order

### DIFF
--- a/SurrealDb.Embedded.Internals/SurrealDbEmbeddedEngine.cs
+++ b/SurrealDb.Embedded.Internals/SurrealDbEmbeddedEngine.cs
@@ -1688,7 +1688,9 @@ internal sealed partial class SurrealDbEmbeddedEngine : ISurrealDbProviderEngine
             };
 
             var sessionBytes = sessionId.HasValue ? sessionId.Value.ToByteArray() : [];
-            var transactionBytes = transactionId.HasValue ? transactionId.Value.ToByteArray() : [];
+            var transactionBytes = transactionId.HasValue
+                ? transactionId.Value.ToByteArray(bigEndian: true)
+                : [];
 
             fixed (byte* session = sessionBytes.AsSpan())
             fixed (byte* transaction = transactionBytes.AsSpan())

--- a/SurrealDb.Net.Tests/TransactionTests.cs
+++ b/SurrealDb.Net.Tests/TransactionTests.cs
@@ -59,7 +59,7 @@ public class TransactionTests
     }
 
     [Test]
-    [WebsocketConnectionStringFixtureGenerator]
+    [ConnectionStringFixtureGenerator]
     [SinceSurrealVersion("3.0")]
     public async Task CommitTransaction(string connectionString)
     {


### PR DESCRIPTION
## Summary

- serialize embedded transaction IDs in RFC byte order before passing them to the Rust UUID parser
- run the existing commit-transaction test against embedded connection fixtures as well as WebSocket

## Why

Embedded transaction IDs originate in Rust and are returned to .NET as GUIDs. System.Guid.ToByteArray() uses the legacy mixed-endian layout by default, while the Rust uuid parser expects RFC byte order. Sending the default byte layout back across the FFI boundary changes the transaction identity, so the first transaction-scoped operation fails with SurrealDbEmbeddedException: Transaction not found.

## Verification

- reproduced the failure on current main with an in-memory embedded transaction: begin succeeds, transaction-scoped create fails with Transaction not found
- the same probe completes after using ToByteArray(bigEndian: true)
- SurrealDb.Embedded.Internals builds successfully for net8.0, net9.0, and net10.0 with zero warnings and zero errors

The existing CommitTransaction test now uses ConnectionStringFixtureGenerator, so CI covers the embedded memory, RocksDB, and SurrealKV providers in addition to WebSocket.