### PR TITLE
Fix embedded UUID byte order

### DIFF
--- a/SurrealDb.Embedded.Internals/SurrealDbEmbeddedEngine.cs
+++ b/SurrealDb.Embedded.Internals/SurrealDbEmbeddedEngine.cs
@@ -1688,7 +1688,9 @@ internal sealed partial class SurrealDbEmbeddedEngine : ISurrealDbProviderEngine
             };
 
             var sessionBytes = sessionId.HasValue ? sessionId.Value.ToByteArray() : [];
-            var transactionBytes = transactionId.HasValue ? transactionId.Value.ToByteArray() : [];
+            var transactionBytes = transactionId.HasValue
+                ? transactionId.Value.ToByteArray(bigEndian: true)
+                : [];
 
             fixed (byte* session = sessionBytes.AsSpan())
             fixed (byte* transaction = transactionBytes.AsSpan())

--- a/SurrealDb.Embedded.Internals/SurrealDbEmbeddedEngine.cs
+++ b/SurrealDb.Embedded.Internals/SurrealDbEmbeddedEngine.cs
@@ -1687,7 +1687,9 @@ internal sealed partial class SurrealDbEmbeddedEngine : ISurrealDbProviderEngine
                 callback = &NativeBindings.FailureCallback,
             };
 
-            var sessionBytes = sessionId.HasValue ? sessionId.Value.ToByteArray() : [];
+            var sessionBytes = sessionId.HasValue
+                ? sessionId.Value.ToByteArray(bigEndian: true)
+                : [];
             var transactionBytes = transactionId.HasValue
                 ? transactionId.Value.ToByteArray(bigEndian: true)
                 : [];


### PR DESCRIPTION
## What is the motivation?

Embedded requests pass .NET Guid values for session and transaction identifiers directly to the Rust native layer.

Those identifiers bypass the CBOR Guid converter. The parameterless Guid.ToByteArray() overload emits .NET's mixed-endian GUID layout, while the native UUID representation expects canonical/RFC byte order. The native layer can therefore receive different identifiers from the session and transaction IDs originally created.

## What does this change do?

Serialize both native-boundary identifiers using canonical byte order:

- sessionId.Value.ToByteArray(bigEndian: true)
- transactionId.Value.ToByteArray(bigEndian: true)

The repository-wide ToByteArray audit found one other call in RandomIdBenchmark. That benchmark converts a newly generated Guid into arbitrary Base64 benchmark input; it does not pass a UUID through the native boundary and is intentionally unchanged.

This replacement PR contains only the production source correction. It excludes the unrelated test-fixture changes that were present in the closed PR #263.

## What is your testing strategy?

- Verified both production ToByteArray calls in SurrealDbEmbeddedEngine use canonical byte order.
- Verified the only remaining parameterless call is benchmark-only and does not represent a native UUID.
- Verified CSharpier formatting.
- Built SurrealDb.Embedded.Internals in Release mode for .NET 8, .NET 9, and .NET 10 with zero warnings and zero errors.
- Verified git diff --check passes.
- Attempted the existing SessionTests suite; local execution is blocked during discovery because the SurrealKV native test library is not present. No test result is claimed from that run.

## Is this related to any issues?

Closes #264.
Supersedes the closed PR #263.

## Have you read the Contributing Guidelines?

- [x] I have read the Contributing Guidelines.