### PR TITLE
🐛Fix RecordId equality and hash code contract

### DIFF
--- a/SurrealDb.Net.Tests/Models/RecordId/EqualityRecordIdTests.cs
+++ b/SurrealDb.Net.Tests/Models/RecordId/EqualityRecordIdTests.cs
@@ -1,0 +1,96 @@
+﻿using SurrealDb.Net.Tests.Serializers.Cbor;
+
+namespace SurrealDb.Net.Tests.Models;
+
+public class EqualityRecordIdTests : BaseCborConverterTests
+{
+    private const string ArrayRecordId = "c88264706f737482664c6f6e646f6e655061726973";
+
+    [Test]
+    public async Task ShouldUseValueEqualityForDeserializedComplexIds()
+    {
+        var first = await DeserializeCborBinaryAsHexaAsync<RecordId>(ArrayRecordId);
+        var second = await DeserializeCborBinaryAsHexaAsync<RecordId>(ArrayRecordId);
+
+        AssertEqualityContract(first, second);
+        ReferenceEquals(first, second).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task ShouldFindEquivalentDeserializedIdInHashCollections()
+    {
+        var stored = await DeserializeCborBinaryAsHexaAsync<RecordId>(ArrayRecordId);
+        var lookup = await DeserializeCborBinaryAsHexaAsync<RecordId>(ArrayRecordId);
+        var set = new HashSet<RecordId> { stored };
+        var dictionary = new Dictionary<RecordId, string> { [stored] = "value" };
+
+        set.Should().Contain(lookup);
+        dictionary.Should().ContainKey(lookup).WhoseValue.Should().Be("value");
+    }
+
+    [Test]
+    public async Task ShouldBeSymmetricAcrossGenericAndDeserializedIds()
+    {
+        var first = new RecordIdOf<string[]>("post", ["London", "Paris"]);
+        var second = await DeserializeCborBinaryAsHexaAsync<RecordId>(ArrayRecordId);
+        var third = new RecordIdOf<List<string>>("post", ["London", "Paris"]);
+
+        AssertEqualityContract(first, second);
+        AssertEqualityContract(second, third);
+        AssertEqualityContract(first, third);
+    }
+
+    [Test]
+    public void ShouldUseStructuralEqualityForObjectAndArrayIds()
+    {
+        var firstObject = new RecordIdOf<Dictionary<string, string>>(
+            "place",
+            new Dictionary<string, string> { ["city"] = "London" }
+        );
+        var secondObject = new RecordIdOf<Dictionary<string, string>>(
+            "place",
+            new Dictionary<string, string> { ["city"] = "London" }
+        );
+        var firstArray = new RecordIdOf<string[]>("place", ["London", "Paris"]);
+        var secondArray = new RecordIdOf<List<string>>("place", ["London", "Paris"]);
+
+        AssertEqualityContract(firstObject, secondObject);
+        AssertEqualityContract(firstArray, secondArray);
+    }
+
+    [Test]
+    public void ShouldTreatEquivalentIntegerRepresentationsAsEqual()
+    {
+        var intId = new RecordIdOf<int>("post", 42);
+        var longId = new RecordIdOf<long>("post", 42L);
+        var unsignedId = new RecordIdOf<uint>("post", 42U);
+
+        AssertEqualityContract(intId, longId);
+        AssertEqualityContract(longId, unsignedId);
+        AssertEqualityContract(intId, unsignedId);
+    }
+
+    [Test]
+    public void ShouldRemainUnequalForDifferentTableOrId()
+    {
+        var expected = new RecordIdOfString("post", "first");
+        var differentTable = new RecordIdOfString("Post", "first");
+        var differentId = new RecordIdOfString("post", "second");
+
+        expected.Equals(differentTable).Should().BeFalse();
+        expected.Equals(differentId).Should().BeFalse();
+        (expected == differentTable).Should().BeFalse();
+        (expected != differentId).Should().BeTrue();
+    }
+
+    private static void AssertEqualityContract(RecordId first, RecordId second)
+    {
+        first.Equals(first).Should().BeTrue();
+        first.Equals(second).Should().BeTrue();
+        second.Equals(first).Should().BeTrue();
+        first.Equals((object)second).Should().BeTrue();
+        (first == second).Should().BeTrue();
+        (first != second).Should().BeFalse();
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+}

--- a/SurrealDb.Net/Internals/Cbor/Converters/RecordIdOfTConverter.cs
+++ b/SurrealDb.Net/Internals/Cbor/Converters/RecordIdOfTConverter.cs
@@ -47,7 +47,7 @@ internal sealed class RecordIdOfTConverter<T> : CborConverterBase<RecordIdOf<T>>
             ?? throw new CborException("Expected a string as the first element of the array");
         var id = CborSerializer.Deserialize<T>(reader.ReadDataItem(), _options);
 
-        return new RecordIdOf<T>(table, id);
+        return new RecordIdOf<T>(table, id, _options);
     }
 
     public override void Write(ref CborWriter writer, RecordIdOf<T> value)

--- a/SurrealDb.Net/Models/RecordId.cs
+++ b/SurrealDb.Net/Models/RecordId.cs
@@ -34,6 +34,18 @@ public partial class RecordId : IEquatable<RecordId>
         _serializedCborId = id;
     }
 
+    internal virtual ReadOnlyMemory<byte> GetSerializedId()
+    {
+        if (!_serializedCborId.HasValue)
+        {
+            throw new InvalidOperationException(
+                $"Failed to execute {nameof(GetSerializedId)}, the record id does not contain the serialized id part."
+            );
+        }
+
+        return _serializedCborId.Value;
+    }
+
     /// <summary>
     /// Deserialize the non-generic id part stored in the record id to the type <typeparamref name="T"/>.
     /// </summary>
@@ -98,16 +110,10 @@ public partial class RecordId : IEquatable<RecordId>
         if (ReferenceEquals(this, other))
             return true;
 
-        if (Table != other.Table)
+        if (!string.Equals(Table, other.Table, StringComparison.Ordinal))
             return false;
 
-        if (!_serializedCborId.HasValue && other._serializedCborId.HasValue)
-            return other.Equals(this);
-
-        if (!_serializedCborId.HasValue || !other._serializedCborId.HasValue)
-            return false;
-
-        return _serializedCborId.Value.Span.SequenceEqual(other._serializedCborId.Value.Span);
+        return GetSerializedId().Span.SequenceEqual(other.GetSerializedId().Span);
     }
 
     public override bool Equals(object? obj)
@@ -120,13 +126,12 @@ public partial class RecordId : IEquatable<RecordId>
 
     public override int GetHashCode()
     {
-        if (!_serializedCborId.HasValue)
-        {
-            throw new InvalidOperationException(
-                $"Failed to execute {nameof(GetHashCode)}, the record id does not contain the serialized id part."
-            );
-        }
+        var hashCode = new HashCode();
+        hashCode.Add(Table, StringComparer.Ordinal);
 
-        return HashCode.Combine(Table, _serializedCborId.Value);
+        foreach (byte value in GetSerializedId().Span)
+            hashCode.Add(value);
+
+        return hashCode.ToHashCode();
     }
 }

--- a/SurrealDb.Net/Models/RecordId.cs
+++ b/SurrealDb.Net/Models/RecordId.cs
@@ -129,8 +129,12 @@ public partial class RecordId : IEquatable<RecordId>
         var hashCode = new HashCode();
         hashCode.Add(Table, StringComparer.Ordinal);
 
+#if NET8_0_OR_GREATER
+        hashCode.AddBytes(GetSerializedId().Span);
+#else
         foreach (byte value in GetSerializedId().Span)
             hashCode.Add(value);
+#endif
 
         return hashCode.ToHashCode();
     }

--- a/SurrealDb.Net/Models/RecordIdOf.cs
+++ b/SurrealDb.Net/Models/RecordIdOf.cs
@@ -8,6 +8,8 @@
 /// <typeparam name="TId">The type of <see cref="RecordIdOf{TId}.Id"/> property.</typeparam>
 public class RecordIdOf<TId> : RecordId
 {
+    private readonly Lazy<ReadOnlyMemory<byte>> _serializedId;
+
     /// <summary>
     /// Id part of the record id.
     /// </summary>
@@ -22,6 +24,25 @@ public class RecordIdOf<TId> : RecordId
         : base(table)
     {
         Id = id;
+        _serializedId = new Lazy<ReadOnlyMemory<byte>>(
+            () => SerializeId(Internals.Cbor.SurrealDbCborOptions.Default.Value)
+        );
+    }
+
+    internal RecordIdOf(string table, TId id, Dahomey.Cbor.CborOptions options)
+        : base(table)
+    {
+        Id = id;
+        _serializedId = new Lazy<ReadOnlyMemory<byte>>(() => SerializeId(options));
+    }
+
+    internal override ReadOnlyMemory<byte> GetSerializedId() => _serializedId.Value;
+
+    private ReadOnlyMemory<byte> SerializeId(Dahomey.Cbor.CborOptions options)
+    {
+        var bufferWriter = new System.Buffers.ArrayBufferWriter<byte>();
+        Dahomey.Cbor.Cbor.Serialize(Id, bufferWriter, options);
+        return bufferWriter.WrittenMemory.ToArray();
     }
 
     public override T DeserializeId<T>()
@@ -52,36 +73,9 @@ public class RecordIdOf<TId> : RecordId
         return false;
     }
 
-    public override bool Equals(RecordId? other)
-    {
-        if (other is null)
-            return false;
+    public override bool Equals(RecordId? other) => base.Equals(other);
 
-        if (ReferenceEquals(this, other))
-            return true;
+    public override bool Equals(object? obj) => base.Equals(obj);
 
-        if (Table != other.Table)
-            return false;
-
-        if (other is RecordIdOf<TId> otherRecordIdOf)
-            return (Id is null && otherRecordIdOf.Id is null) || Id!.Equals(otherRecordIdOf.Id);
-
-        if (!other.TryDeserializeId(out TId otherId))
-            return false;
-
-        return (Id is null && otherId is null) || Id!.Equals(otherId);
-    }
-
-    public override bool Equals(object? obj)
-    {
-        if (obj is RecordId other)
-            return Equals(other);
-
-        return base.Equals(obj);
-    }
-
-    public override int GetHashCode()
-    {
-        return HashCode.Combine(Table, Id);
-    }
+    public override int GetHashCode() => base.GetHashCode();
 }


### PR DESCRIPTION
## What is the motivation?

Equal `RecordId` values could produce different hash codes, breaking lookups in hash-based collections. Complex generic IDs also used CLR reference equality.

## What does this change do?

Uses the serialized CBOR ID bytes consistently for equality and hashing. Table names remain case-sensitive, and deserialized generic IDs retain their CBOR options.

## What is your testing strategy?

Added tests for complex and deserialized IDs, generic representations, numeric types, and `HashSet` / `Dictionary` lookups. All supported target frameworks build successfully.

## Is this related to any issues?

Closes #269

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)