### PR TITLE
🐛Fix restore forked session configuration

### DIFF
--- a/SurrealDb.Net.Tests/SessionTests.cs
+++ b/SurrealDb.Net.Tests/SessionTests.cs
@@ -121,9 +121,8 @@ public class SessionTests
         result.SessionId.Should().NotBeNull();
         result.SessionId!.Value.Should().NotBe(firstSession.SessionId!.Value);
 
-        var response = await result.RawQuery("RETURN <string>encoding::json::encode($session);");
-
-        response.GetValue<string>(0).Should().NotBeNullOrEmpty();
+        // INFO FOR DB requires both the selected database and root authentication.
+        (await result.RawQuery("INFO FOR DB;")).EnsureAllOks();
 
         await firstSession.DisposeAsync();
     }

--- a/SurrealDb.Net.Tests/SessionTests.cs
+++ b/SurrealDb.Net.Tests/SessionTests.cs
@@ -106,7 +106,7 @@ public class SessionTests
     }
 
     [Test]
-    [ConnectionStringFixtureGenerator]
+    [WebsocketConnectionStringFixtureGenerator]
     [SinceSurrealVersion("3.0")]
     public async Task ForkSession(string connectionString)
     {
@@ -114,9 +114,16 @@ public class SessionTests
 
         await using var client = surrealDbClientGenerator.Create(connectionString);
         var firstSession = await client.CreateSession();
+        await firstSession.SignIn(new RootAuth { Username = "root", Password = "root" });
+        await firstSession.Use("test", "test");
         await using var result = await firstSession.ForkSession();
 
         result.SessionId.Should().NotBeNull();
+        result.SessionId!.Value.Should().NotBe(firstSession.SessionId!.Value);
+
+        var response = await result.RawQuery("RETURN <string>encoding::json::encode($session);");
+
+        response.GetValue<string>(0).Should().NotBeNullOrEmpty();
 
         await firstSession.DisposeAsync();
     }

--- a/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
+++ b/SurrealDb.Net/Internals/SurrealDbEngine.Ws.cs
@@ -463,6 +463,8 @@ internal sealed class SurrealDbWsEngine : ISurrealDbEngine
         await Attach(newId, cancellationToken).ConfigureAwait(false);
         SessionInfos.Set(newId, newState);
 
+        await ApplyConfigurationAsync(newId, null, cancellationToken).ConfigureAwait(false);
+
         return newId;
     }
 


### PR DESCRIPTION
## What is the motivation?

Forked WebSocket sessions did not restore their source authentication or namespace/database state on the server. Queries through the fork therefore failed with anonymous-access errors.

## What does this change do?

Applies the cloned session configuration after attaching a forked WebSocket session, restoring its `USE` context and authentication. Adds a WebSocket regression test covering authenticated forks.

## What is your testing strategy?

- `dotnet build SurrealDb.Net.Tests/SurrealDb.Net.Tests.csproj --no-restore`
- Complete integration test suite against a local SurrealDB instance: 594 passed, 8 skipped, 0 failed.

## Is this related to any issues?

Fixes #272.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.net/blob/main/CONTRIBUTING.md)